### PR TITLE
feat: add format_version_with_commit() for foundry to print ssolc version

### DIFF
--- a/crates/compilers/src/compilers/solc/mod.rs
+++ b/crates/compilers/src/compilers/solc/mod.rs
@@ -83,11 +83,15 @@ impl Compiler for SolcCompiler {
 
     fn available_versions(&self, _language: &Self::Language) -> Vec<CompilerVersion> {
         match self {
-            Self::Specific(solc) => vec![CompilerVersion::Installed(Version::new(
-                solc.version.major,
-                solc.version.minor,
-                solc.version.patch,
-            ))],
+            Self::Specific(solc) => {
+                let mut v = Version::new(
+                    solc.version.major,
+                    solc.version.minor,
+                    solc.version.patch,
+                );
+                v.build = solc.version.build.clone();
+                vec![CompilerVersion::Installed(v)]
+            }
 
             #[cfg(feature = "svm-solc")]
             Self::AutoDetect => {
@@ -158,7 +162,7 @@ impl CompilerInput for SolcVersionedInput {
     }
 
     fn compiler_name(&self) -> Cow<'static, str> {
-        "Solc".into()
+        "ssolc".into()
     }
 
     fn strip_prefix(&mut self, base: &Path) {

--- a/crates/compilers/src/compilers/solc/mod.rs
+++ b/crates/compilers/src/compilers/solc/mod.rs
@@ -84,11 +84,8 @@ impl Compiler for SolcCompiler {
     fn available_versions(&self, _language: &Self::Language) -> Vec<CompilerVersion> {
         match self {
             Self::Specific(solc) => {
-                let mut v = Version::new(
-                    solc.version.major,
-                    solc.version.minor,
-                    solc.version.patch,
-                );
+                let mut v =
+                    Version::new(solc.version.major, solc.version.minor, solc.version.patch);
                 v.build = solc.version.build.clone();
                 vec![CompilerVersion::Installed(v)]
             }

--- a/crates/compilers/src/report/mod.rs
+++ b/crates/compilers/src/report/mod.rs
@@ -323,19 +323,18 @@ impl Reporter for BasicStdoutReporter {
     /// [`Compiler::compile()`]: crate::compilers::Compiler::compile
     fn on_compiler_spawn(&self, compiler_name: &str, version: &Version, dirty_files: &[PathBuf]) {
         println!(
-            "Compiling {} files with {} {}.{}.{}",
+            "Compiling {} files with {} {}",
             dirty_files.len(),
             compiler_name,
-            version.major,
-            version.minor,
-            version.patch
+            format_version_with_commit(version),
         );
     }
 
     fn on_compiler_success(&self, compiler_name: &str, version: &Version, duration: &Duration) {
         println!(
-            "{} {}.{}.{} finished in {duration:.2?}",
-            compiler_name, version.major, version.minor, version.patch
+            "{} {} finished in {duration:.2?}",
+            compiler_name,
+            format_version_with_commit(version),
         );
     }
 
@@ -373,6 +372,25 @@ pub fn format_unresolved_imports(imports: &[(&Path, &Path)], remappings: &[Remap
         info,
         remappings.iter().map(|r| r.to_string()).collect::<Vec<_>>().join("\n      ")
     )
+}
+
+/// Extract short commit hash from version build metadata.
+/// Handles format like "commit.676bdecc.Darwin.appleclang" → "676bdec"
+pub fn extract_short_commit(version: &Version) -> Option<&str> {
+    let build = version.build.as_str();
+    let hash = build.strip_prefix("commit.")?;
+    let end = hash.find('.').unwrap_or(hash.len()).min(7);
+    Some(&hash[..end])
+}
+
+/// Format version with optional short commit hash for display.
+/// Returns e.g. "0.8.31 (676bdec)" or "0.8.31" if no commit metadata.
+pub fn format_version_with_commit(version: &Version) -> String {
+    if let Some(hash) = extract_short_commit(version) {
+        format!("{}.{}.{} ({hash})", version.major, version.minor, version.patch)
+    } else {
+        format!("{}.{}.{}", version.major, version.minor, version.patch)
+    }
 }
 
 /// Returned if setting the global reporter fails.


### PR DESCRIPTION
Right now we only see "compiling with solc 0.8.31" or whatever... which is confusing because we don't know which exact build its coming from. We don't use semver yet for our ssolc fork so its better to have commit from where it was built.

When compiling we'll thus see the commit version (tested this in foundry using this commit)
```
$ ../../seismic-foundry/target/debug/sforge build -vvv
[⠊] Compiling...
[⠑] Compiling 44 files with ssolc 0.8.31 (676bdec)
[⠘] ssolc 0.8.31 (676bdec) finished in 615.21ms
```

Before we'd see `Compiler ... with Solc 0.8.31` only.