### PR TITLE
fix: mercury versioning

### DIFF
--- a/crates/artifacts/solc/src/lib.rs
+++ b/crates/artifacts/solc/src/lib.rs
@@ -2024,7 +2024,6 @@ mod tests {
             ("0.8.26", EvmVersion::Cancun, Some(EvmVersion::Cancun)),
             ("0.8.26", EvmVersion::Prague, Some(EvmVersion::Cancun)),
             ("0.8.27", EvmVersion::Prague, Some(EvmVersion::Prague)),
-            // Osaka
             ("0.8.29", EvmVersion::Osaka, Some(EvmVersion::Osaka)),
             // Mercury
             // This one is a bit weird... based on the version only you'd think it would clip to

--- a/crates/artifacts/solc/src/lib.rs
+++ b/crates/artifacts/solc/src/lib.rs
@@ -38,8 +38,8 @@ use foundry_compilers_core::{
     error::SolcError,
     utils::{
         strip_prefix_owned, BERLIN_SOLC, BYZANTIUM_SOLC, CANCUN_SOLC, CONSTANTINOPLE_SOLC,
-        ISTANBUL_SOLC, LONDON_SOLC, OSAKA_SOLC, PARIS_SOLC, PETERSBURG_SOLC, PRAGUE_SOLC,
-        SHANGHAI_SOLC,
+        ISTANBUL_SOLC, LONDON_SOLC, MERCURY_SOLC, OSAKA_SOLC, PARIS_SOLC, PETERSBURG_SOLC,
+        PRAGUE_SOLC, SHANGHAI_SOLC,
     },
 };
 pub use serde_helpers::{deserialize_bytes, deserialize_opt_bytes};
@@ -811,9 +811,10 @@ pub enum EvmVersion {
     Paris,
     Shanghai,
     Cancun,
+    Prague,
+    // Currently Mercury is built on top of Ethereum's Prague hardfork.
     #[default]
     Mercury,
-    Prague,
     Osaka,
 }
 
@@ -849,12 +850,11 @@ impl EvmVersion {
     pub fn normalize_version_solc(self, version: &Version) -> Option<Self> {
         // The EVM version flag was only added in 0.4.21; we work our way backwards
         if *version >= BYZANTIUM_SOLC {
-            if *version >= foundry_compilers_core::utils::MERCURY_SOLC {
-                return Some(Self::Mercury);
-            }
             // If the Solc version is the latest, it supports all EVM versions.
             // For all other cases, cap at the at-the-time highest possible fork.
-            let normalized = if *version >= OSAKA_SOLC {
+            let normalized = if *version >= MERCURY_SOLC {
+                self
+            } else if self >= Self::Osaka && *version >= OSAKA_SOLC {
                 Self::Osaka
             } else if self >= Self::Prague && *version >= PRAGUE_SOLC {
                 Self::Prague
@@ -888,7 +888,6 @@ impl EvmVersion {
     /// Returns the EVM version as a string.
     pub const fn as_str(&self) -> &'static str {
         match self {
-            Self::Mercury => "mercury",
             Self::Homestead => "homestead",
             Self::TangerineWhistle => "tangerineWhistle",
             Self::SpuriousDragon => "spuriousDragon",
@@ -902,6 +901,7 @@ impl EvmVersion {
             Self::Shanghai => "shanghai",
             Self::Cancun => "cancun",
             Self::Prague => "prague",
+            Self::Mercury => "mercury",
             Self::Osaka => "osaka",
         }
     }
@@ -959,7 +959,6 @@ impl FromStr for EvmVersion {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "mercury" => Ok(Self::Mercury),
             "homestead" => Ok(Self::Homestead),
             "tangerineWhistle" | "tangerinewhistle" => Ok(Self::TangerineWhistle),
             "spuriousDragon" | "spuriousdragon" => Ok(Self::SpuriousDragon),
@@ -973,6 +972,7 @@ impl FromStr for EvmVersion {
             "shanghai" => Ok(Self::Shanghai),
             "cancun" => Ok(Self::Cancun),
             "prague" => Ok(Self::Prague),
+            "mercury" => Ok(Self::Mercury),
             "osaka" => Ok(Self::Osaka),
             s => Err(format!("Unknown evm version: {s}")),
         }
@@ -2024,9 +2024,14 @@ mod tests {
             ("0.8.26", EvmVersion::Cancun, Some(EvmVersion::Cancun)),
             ("0.8.26", EvmVersion::Prague, Some(EvmVersion::Cancun)),
             ("0.8.27", EvmVersion::Prague, Some(EvmVersion::Prague)),
-            //Mercury
-            ("0.8.28", EvmVersion::Mercury, Some(EvmVersion::Mercury)),
-            ("0.8.29", EvmVersion::Osaka, Some(EvmVersion::Mercury)),
+            // Osaka
+            ("0.8.29", EvmVersion::Osaka, Some(EvmVersion::Osaka)),
+            // Mercury
+            // This one is a bit weird... based on the version only you'd think it would clip to
+            // Osaka, but actually in terms EvmVersions Prague < Mercury < Osaka.
+            ("0.8.30", EvmVersion::Mercury, Some(EvmVersion::Prague)),
+            ("0.8.31", EvmVersion::Osaka, Some(EvmVersion::Osaka)),
+            ("0.8.31", EvmVersion::Mercury, Some(EvmVersion::Mercury)),
         ] {
             let version = Version::from_str(solc_version).unwrap();
             assert_eq!(

--- a/crates/artifacts/solc/src/lib.rs
+++ b/crates/artifacts/solc/src/lib.rs
@@ -1965,7 +1965,7 @@ mod tests {
             // Cancun
             ("0.8.24", Some(EvmVersion::Shanghai)),
             ("0.8.25", Some(EvmVersion::Cancun)),
-            ("0.8.28", Some(EvmVersion::Mercury)),
+            ("0.8.31", Some(EvmVersion::Mercury)),
         ] {
             let version = Version::from_str(solc_version).unwrap();
             assert_eq!(

--- a/crates/core/src/utils/mod.rs
+++ b/crates/core/src/utils/mod.rs
@@ -26,9 +26,6 @@ pub use wd::*;
 /// Extensions acceptable by solc compiler.
 pub const SOLC_EXTENSIONS: &[&str] = &["sol", "yul"];
 
-/// Mercury support (Seismic)
-pub const MERCURY_SOLC: Version = Version::new(0, 8, 28);
-
 /// Support for configuring the EVM version
 /// <https://blog.soliditylang.org/2018/03/08/solidity-0.4.21-release-announcement/>
 pub const BYZANTIUM_SOLC: Version = Version::new(0, 4, 21);
@@ -72,6 +69,18 @@ pub const PRAGUE_SOLC: Version = Version::new(0, 8, 27);
 /// Osaka support
 /// <https://soliditylang.org/blog/2025/03/12/solidity-0.8.29-release-announcement>
 pub const OSAKA_SOLC: Version = Version::new(0, 8, 29);
+
+/// Mercury support (Seismic)
+///
+/// This is a minimum version floor — "Mercury support requires at least 0.8.31".
+/// It should match the upstream version that seismic-solidity was built on.
+/// The latest upstream rebase (to 0.8.31) is: https://github.com/SeismicSystems/seismic-solidity/pull/83
+/// If we ever decide to do another rebase on top of a later solidity version before finalizing the
+/// mercury evm-version feature set, then we will need to update this version.
+///
+/// Note also that despite its solc version being > osaka, in terms of feature sets (see EvmVersion
+/// enum), Mercury currently only enables Ethereum's Prague hardfork, not Osaka.
+pub const MERCURY_SOLC: Version = Version::new(0, 8, 31);
 
 // `--base-path` was introduced in 0.6.9 <https://github.com/ethereum/solidity/releases/tag/v0.6.9>
 pub static SUPPORTS_BASE_PATH: Lazy<VersionReq> =


### PR DESCRIPTION
bump to 0.8.31. also make mercury between prague and osaka, as it is in revm and solidity.