### PR TITLE
fix: mercury solc version 0.8.31->0.8.30

### DIFF
--- a/crates/artifacts/solc/src/lib.rs
+++ b/crates/artifacts/solc/src/lib.rs
@@ -1965,6 +1965,7 @@ mod tests {
             // Cancun
             ("0.8.24", Some(EvmVersion::Shanghai)),
             ("0.8.25", Some(EvmVersion::Cancun)),
+            ("0.8.30", Some(EvmVersion::Mercury)),
             ("0.8.31", Some(EvmVersion::Mercury)),
         ] {
             let version = Version::from_str(solc_version).unwrap();
@@ -2026,9 +2027,7 @@ mod tests {
             ("0.8.27", EvmVersion::Prague, Some(EvmVersion::Prague)),
             ("0.8.29", EvmVersion::Osaka, Some(EvmVersion::Osaka)),
             // Mercury
-            // This one is a bit weird... based on the version only you'd think it would clip to
-            // Osaka, but actually in terms EvmVersions Prague < Mercury < Osaka.
-            ("0.8.30", EvmVersion::Mercury, Some(EvmVersion::Prague)),
+            ("0.8.30", EvmVersion::Mercury, Some(EvmVersion::Mercury)),
             ("0.8.31", EvmVersion::Osaka, Some(EvmVersion::Osaka)),
             ("0.8.31", EvmVersion::Mercury, Some(EvmVersion::Mercury)),
         ] {

--- a/crates/core/src/utils/mod.rs
+++ b/crates/core/src/utils/mod.rs
@@ -72,15 +72,19 @@ pub const OSAKA_SOLC: Version = Version::new(0, 8, 29);
 
 /// Mercury support (Seismic)
 ///
-/// This is a minimum version floor — "Mercury support requires at least 0.8.31".
+/// This is a minimum version floor — "Mercury support requires at least 0.8.30".
 /// It should match the upstream version that seismic-solidity was built on.
-/// The latest upstream rebase (to 0.8.31) is: https://github.com/SeismicSystems/seismic-solidity/pull/83
+/// The latest upstream rebase is: https://github.com/SeismicSystems/seismic-solidity/pull/83,
+/// which rebased on top of some commit between 0.8.30 and 0.8.31.
 /// If we ever decide to do another rebase on top of a later solidity version before finalizing the
 /// mercury evm-version feature set, then we will need to update this version.
 ///
+/// Note: we use 0.8.30 (not 0.8.31) because ssolc reports a pre-release version
+/// (e.g. 0.8.31-develop...) which is less than 0.8.31 in semver comparison.
+///
 /// Note also that despite its solc version being > osaka, in terms of feature sets (see EvmVersion
 /// enum), Mercury currently only enables Ethereum's Prague hardfork, not Osaka.
-pub const MERCURY_SOLC: Version = Version::new(0, 8, 31);
+pub const MERCURY_SOLC: Version = Version::new(0, 8, 30);
 
 // `--base-path` was introduced in 0.6.9 <https://github.com/ethereum/solidity/releases/tag/v0.6.9>
 pub static SUPPORTS_BASE_PATH: Lazy<VersionReq> =


### PR DESCRIPTION
We need 0.8.30 (not 0.8.31) because ssolc reports a pre-release version (e.g. 0.8.31-develop...) which is less than 0.8.31 in semver comparison, and so sforge was instead injecting prague evm_version into ssolc.