### PR TITLE
feat(settings): support for unsafe-via-ir config setting

### DIFF
--- a/crates/artifacts/solc/src/lib.rs
+++ b/crates/artifacts/solc/src/lib.rs
@@ -261,6 +261,11 @@ pub struct Settings {
     /// false by default.
     #[serde(rename = "viaIR", default, skip_serializing_if = "Option::is_none")]
     pub via_ir: Option<bool>,
+    /// Allow via-IR pipeline on Seismic's ssolc (experimental, shielded type support incomplete).
+    /// Needed since https://github.com/SeismicSystems/seismic-solidity/pull/204
+    /// Temporary flag while via-ir is experimental and may contain bugs.
+    #[serde(rename = "unsafeViaIR", default, skip_serializing_if = "Option::is_none")]
+    pub unsafe_via_ir: Option<bool>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub debug: Option<DebuggingSettings>,
     /// Addresses of the libraries. If not all libraries are given here,
@@ -553,6 +558,7 @@ impl Default for Settings {
             output_selection: OutputSelection::default_output_selection(),
             evm_version: Some(EvmVersion::default()),
             via_ir: None,
+            unsafe_via_ir: None,
             debug: None,
             libraries: Default::default(),
             remappings: Default::default(),

--- a/crates/compilers/src/compilers/solc/mod.rs
+++ b/crates/compilers/src/compilers/solc/mod.rs
@@ -305,6 +305,7 @@ impl CompilerSettings for SolcSettings {
                     output_selection,
                     evm_version,
                     via_ir,
+                    unsafe_via_ir,
                     debug,
                     libraries,
                 },
@@ -318,6 +319,7 @@ impl CompilerSettings for SolcSettings {
             && *metadata == other.settings.metadata
             && *evm_version == other.settings.evm_version
             && *via_ir == other.settings.via_ir
+            && *unsafe_via_ir == other.settings.unsafe_via_ir
             && *debug == other.settings.debug
             && *libraries == other.settings.libraries
             && output_selection.is_subset_of(&other.settings.output_selection)


### PR DESCRIPTION
Needed since we added this flag to ssolc to make sure users are aware when using --via-ir that it is experimental.