### PR TITLE
feat: seismic warning suppression config

### DIFF
--- a/crates/compilers/src/compile/output/mod.rs
+++ b/crates/compilers/src/compile/output/mod.rs
@@ -2,7 +2,8 @@
 
 // Seismic warnings use error codes >= 10000. By default these are suppressed
 // in test files (not scripts, not src). The `seismic_warnings_in_tests` flag
-// can be set to disable this suppression.
+// can be set to disable this suppression. The `no_seismic_warnings` flag
+// suppresses ALL seismic warnings globally (in src, test, and script files).
 
 /// The minimum error code for seismic-specific warnings.
 const SEISMIC_WARNING_THRESHOLD: u64 = 10000;
@@ -88,6 +89,8 @@ pub struct ProjectCompileOutput<
     pub(crate) ignored_file_paths: Vec<PathBuf>,
     /// When true, seismic warnings (code >= 10000) are shown even in test files.
     pub(crate) seismic_warnings_in_tests: bool,
+    /// When true, suppress ALL seismic warnings (code >= 10000) globally.
+    pub(crate) no_seismic_warnings: bool,
     /// set minimum level of severity that is treated as an error
     pub(crate) compiler_severity_filter: Severity,
     /// all build infos that were just compiled
@@ -500,6 +503,7 @@ impl<C: Compiler, T: ArtifactOutput<CompilerContract = C::CompilerContract>>
             &self.ignored_file_paths,
             &self.compiler_severity_filter,
             self.seismic_warnings_in_tests,
+            self.no_seismic_warnings,
         )
     }
 
@@ -509,6 +513,7 @@ impl<C: Compiler, T: ArtifactOutput<CompilerContract = C::CompilerContract>>
             &self.ignored_error_codes,
             &self.ignored_file_paths,
             self.seismic_warnings_in_tests,
+            self.no_seismic_warnings,
         )
     }
 
@@ -539,6 +544,7 @@ impl<C: Compiler, T: ArtifactOutput<CompilerContract = C::CompilerContract>> fmt
                     &self.ignored_file_paths,
                     self.compiler_severity_filter,
                     self.seismic_warnings_in_tests,
+                    self.no_seismic_warnings,
                 )
                 .fmt(f)
         }
@@ -584,6 +590,7 @@ impl<C: Compiler> AggregatedCompilerOutput<C> {
         ignored_file_paths: &'a [PathBuf],
         compiler_severity_filter: Severity,
         seismic_warnings_in_tests: bool,
+        no_seismic_warnings: bool,
     ) -> OutputDiagnostics<'a, C> {
         OutputDiagnostics {
             compiler_output: self,
@@ -591,6 +598,7 @@ impl<C: Compiler> AggregatedCompilerOutput<C> {
             ignored_file_paths,
             compiler_severity_filter,
             seismic_warnings_in_tests,
+            no_seismic_warnings,
         }
     }
 
@@ -852,6 +860,7 @@ impl<C: Compiler> AggregatedCompilerOutput<C> {
         ignored_file_paths: &[PathBuf],
         compiler_severity_filter: &Severity,
         seismic_warnings_in_tests: bool,
+        no_seismic_warnings: bool,
     ) -> bool {
         self.errors.iter().any(|err| {
             if err.is_error() {
@@ -866,6 +875,7 @@ impl<C: Compiler> AggregatedCompilerOutput<C> {
                         ignored_error_codes,
                         ignored_file_paths,
                         seismic_warnings_in_tests,
+                        no_seismic_warnings,
                     );
                 }
                 return true;
@@ -881,12 +891,14 @@ impl<C: Compiler> AggregatedCompilerOutput<C> {
         ignored_error_codes: &[u64],
         ignored_file_paths: &[PathBuf],
         seismic_warnings_in_tests: bool,
+        no_seismic_warnings: bool,
     ) -> bool {
         self.errors.iter().any(|error| {
             !self.should_ignore(
                 ignored_error_codes,
                 ignored_file_paths,
                 seismic_warnings_in_tests,
+                no_seismic_warnings,
                 error,
             )
         })
@@ -897,6 +909,7 @@ impl<C: Compiler> AggregatedCompilerOutput<C> {
         ignored_error_codes: &[u64],
         ignored_file_paths: &[PathBuf],
         seismic_warnings_in_tests: bool,
+        no_seismic_warnings: bool,
         error: &C::CompilationError,
     ) -> bool {
         if !error.is_warning() {
@@ -907,6 +920,13 @@ impl<C: Compiler> AggregatedCompilerOutput<C> {
 
         if let Some(code) = error.error_code() {
             ignore |= ignored_error_codes.contains(&code);
+
+            // When no_seismic_warnings is set, suppress ALL seismic warnings globally
+            // (in src, test, and script files).
+            if no_seismic_warnings && code >= SEISMIC_WARNING_THRESHOLD {
+                return true;
+            }
+
             if let Some(loc) = error.source_location() {
                 let path = Path::new(&loc.file);
                 ignore |=
@@ -967,6 +987,8 @@ pub struct OutputDiagnostics<'a, C: Compiler> {
     compiler_severity_filter: Severity,
     /// When true, seismic warnings (code >= 10000) are shown even in test files.
     seismic_warnings_in_tests: bool,
+    /// When true, suppress ALL seismic warnings (code >= 10000) globally.
+    no_seismic_warnings: bool,
 }
 
 impl<C: Compiler> OutputDiagnostics<'_, C> {
@@ -977,6 +999,7 @@ impl<C: Compiler> OutputDiagnostics<'_, C> {
             self.ignored_file_paths,
             &self.compiler_severity_filter,
             self.seismic_warnings_in_tests,
+            self.no_seismic_warnings,
         )
     }
 
@@ -986,6 +1009,7 @@ impl<C: Compiler> OutputDiagnostics<'_, C> {
             self.ignored_error_codes,
             self.ignored_file_paths,
             self.seismic_warnings_in_tests,
+            self.no_seismic_warnings,
         )
     }
 }
@@ -1006,6 +1030,7 @@ impl<C: Compiler> fmt::Display for OutputDiagnostics<'_, C> {
                 self.ignored_error_codes,
                 self.ignored_file_paths,
                 self.seismic_warnings_in_tests,
+                self.no_seismic_warnings,
                 err,
             ) {
                 f.write_str("\n")?;
@@ -1075,14 +1100,21 @@ mod tests {
     fn is_suppressed(code: u64, file: &str) -> bool {
         let output = make_output();
         let warning = make_warning(code, file);
-        output.should_ignore(&[], &[], false, &warning)
+        output.should_ignore(&[], &[], false, false, &warning)
     }
 
     /// Helper: returns true if the warning would be suppressed with the given flag.
     fn is_suppressed_with_flag(code: u64, file: &str, seismic_warnings_in_tests: bool) -> bool {
         let output = make_output();
         let warning = make_warning(code, file);
-        output.should_ignore(&[], &[], seismic_warnings_in_tests, &warning)
+        output.should_ignore(&[], &[], seismic_warnings_in_tests, false, &warning)
+    }
+
+    /// Helper: returns true if the warning would be suppressed with no_seismic_warnings set.
+    fn is_suppressed_no_seismic(code: u64, file: &str) -> bool {
+        let output = make_output();
+        let warning = make_warning(code, file);
+        output.should_ignore(&[], &[], false, true, &warning)
     }
 
     #[test]
@@ -1114,9 +1146,40 @@ mod tests {
     }
 
     #[test]
+    fn no_seismic_warnings_suppresses_in_src() {
+        assert!(is_suppressed_no_seismic(10001, "src/Foo.sol"));
+        assert!(is_suppressed_no_seismic(15000, "src/Foo.sol"));
+    }
+
+    #[test]
+    fn no_seismic_warnings_suppresses_in_test() {
+        assert!(is_suppressed_no_seismic(10001, "test/Foo.t.sol"));
+    }
+
+    #[test]
+    fn no_seismic_warnings_suppresses_in_script() {
+        assert!(is_suppressed_no_seismic(10001, "script/Deploy.s.sol"));
+        assert!(is_suppressed_no_seismic(10001, "scripts/Deploy.s.sol"));
+    }
+
+    #[test]
+    fn no_seismic_warnings_does_not_suppress_non_seismic() {
+        let output = make_output();
+        let warning = make_warning(9999, "src/Foo.sol");
+        assert!(!output.should_ignore(&[], &[], false, true, &warning));
+    }
+
+    #[test]
     fn errors_never_suppressed() {
         let output = make_output();
         let error = make_error(10001, "test/Foo.t.sol");
-        assert!(!output.should_ignore(&[], &[], false, &error));
+        assert!(!output.should_ignore(&[], &[], false, false, &error));
+    }
+
+    #[test]
+    fn errors_never_suppressed_even_with_no_seismic_warnings() {
+        let output = make_output();
+        let error = make_error(10001, "src/Foo.sol");
+        assert!(!output.should_ignore(&[], &[], false, true, &error));
     }
 }

--- a/crates/compilers/src/compile/output/mod.rs
+++ b/crates/compilers/src/compile/output/mod.rs
@@ -1,62 +1,11 @@
 //! The output of a compiled project
 
-// The Seismic Solidity compiler (ssolc) emits warnings when literals are
-// converted to shielded types. These IDs are grouped by AST context so that
-// downstream tools can selectively suppress them.
+// Seismic warnings use error codes >= 10000. By default these are suppressed
+// in test files (not scripts, not src). The `seismic_warnings_in_tests` flag
+// can be set to disable this suppression.
 
-/// Constructor has shielded parameter types.
-/// CREATE/CREATE2 does not encrypt calldata, so values leak in deployment tx.
-/// Not suppressed in any context — always relevant.
-#[cfg(test)]
-const SHIELDED_CONSTRUCTOR_PARAM: u64 = 5500;
-
-/// Shielded literal warnings: literal inside `new(...)` expression args.
-/// Child contract is deployed via CREATE — literal leaks in init code.
-/// Not suppressed in any context — always relevant.
-#[cfg(test)]
-const SHIELDED_LITERAL_NEW_EXPR_INT: u64 = 5501;
-#[cfg(test)]
-const SHIELDED_LITERAL_NEW_EXPR_BOOL: u64 = 5502;
-#[cfg(test)]
-const SHIELDED_LITERAL_NEW_EXPR_ADDRESS: u64 = 5503;
-#[cfg(test)]
-const SHIELDED_LITERAL_NEW_EXPR_FIXEDBYTES: u64 = 5504;
-#[cfg(test)]
-const SHIELDED_LITERAL_NEW_EXPR_ENUM: u64 = 5505;
-
-/// Shielded literal warnings: literal inside external call args.
-/// Literal is in caller bytecode, but calldata is encrypted by TxSeismic.
-/// Safe to suppress in test/script files.
-const SHIELDED_LITERAL_EXT_CALL_INT: u64 = 5506;
-const SHIELDED_LITERAL_EXT_CALL_BOOL: u64 = 5507;
-const SHIELDED_LITERAL_EXT_CALL_ADDRESS: u64 = 5508;
-const SHIELDED_LITERAL_EXT_CALL_FIXEDBYTES: u64 = 5509;
-const SHIELDED_LITERAL_EXT_CALL_ENUM: u64 = 5510;
-
-/// Shielded literal warnings: literal in other contexts (assignments, internal calls, etc.).
-/// Literal is embedded in contract bytecode.
-/// Safe to suppress in test/script files where bytecode is never deployed.
-const SHIELDED_LITERAL_OTHER_INT: u64 = 9660;
-const SHIELDED_LITERAL_OTHER_BOOL: u64 = 9661;
-const SHIELDED_LITERAL_OTHER_ADDRESS: u64 = 9662;
-const SHIELDED_LITERAL_OTHER_FIXEDBYTES: u64 = 9663;
-const SHIELDED_LITERAL_OTHER_ENUM: u64 = 1457;
-
-/// Warnings suppressed in test/script files — bytecode never deployed, calldata encrypted.
-const SHIELDED_WARNINGS_SUPPRESSIBLE_IN_TESTS: &[u64] = &[
-    // External call context
-    SHIELDED_LITERAL_EXT_CALL_INT,
-    SHIELDED_LITERAL_EXT_CALL_BOOL,
-    SHIELDED_LITERAL_EXT_CALL_ADDRESS,
-    SHIELDED_LITERAL_EXT_CALL_FIXEDBYTES,
-    SHIELDED_LITERAL_EXT_CALL_ENUM,
-    // Other context
-    SHIELDED_LITERAL_OTHER_INT,
-    SHIELDED_LITERAL_OTHER_BOOL,
-    SHIELDED_LITERAL_OTHER_ADDRESS,
-    SHIELDED_LITERAL_OTHER_FIXEDBYTES,
-    SHIELDED_LITERAL_OTHER_ENUM,
-];
+/// The minimum error code for seismic-specific warnings.
+const SEISMIC_WARNING_THRESHOLD: u64 = 10000;
 
 use contracts::{VersionedContract, VersionedContracts};
 use foundry_compilers_artifacts::{CompactContractBytecode, CompactContractRef, Severity};
@@ -137,6 +86,8 @@ pub struct ProjectCompileOutput<
     pub(crate) ignored_error_codes: Vec<u64>,
     /// paths that should be omitted
     pub(crate) ignored_file_paths: Vec<PathBuf>,
+    /// When true, seismic warnings (code >= 10000) are shown even in test files.
+    pub(crate) seismic_warnings_in_tests: bool,
     /// set minimum level of severity that is treated as an error
     pub(crate) compiler_severity_filter: Severity,
     /// all build infos that were just compiled
@@ -548,12 +499,17 @@ impl<C: Compiler, T: ArtifactOutput<CompilerContract = C::CompilerContract>>
             &self.ignored_error_codes,
             &self.ignored_file_paths,
             &self.compiler_severity_filter,
+            self.seismic_warnings_in_tests,
         )
     }
 
     /// Returns whether any warnings were emitted by the compiler.
     pub fn has_compiler_warnings(&self) -> bool {
-        self.compiler_output.has_warning(&self.ignored_error_codes, &self.ignored_file_paths)
+        self.compiler_output.has_warning(
+            &self.ignored_error_codes,
+            &self.ignored_file_paths,
+            self.seismic_warnings_in_tests,
+        )
     }
 
     /// Panics if any errors were emitted by the compiler.
@@ -582,6 +538,7 @@ impl<C: Compiler, T: ArtifactOutput<CompilerContract = C::CompilerContract>> fmt
                     &self.ignored_error_codes,
                     &self.ignored_file_paths,
                     self.compiler_severity_filter,
+                    self.seismic_warnings_in_tests,
                 )
                 .fmt(f)
         }
@@ -626,12 +583,14 @@ impl<C: Compiler> AggregatedCompilerOutput<C> {
         ignored_error_codes: &'a [u64],
         ignored_file_paths: &'a [PathBuf],
         compiler_severity_filter: Severity,
+        seismic_warnings_in_tests: bool,
     ) -> OutputDiagnostics<'a, C> {
         OutputDiagnostics {
             compiler_output: self,
             ignored_error_codes,
             ignored_file_paths,
             compiler_severity_filter,
+            seismic_warnings_in_tests,
         }
     }
 
@@ -892,6 +851,7 @@ impl<C: Compiler> AggregatedCompilerOutput<C> {
         ignored_error_codes: &[u64],
         ignored_file_paths: &[PathBuf],
         compiler_severity_filter: &Severity,
+        seismic_warnings_in_tests: bool,
     ) -> bool {
         self.errors.iter().any(|err| {
             if err.is_error() {
@@ -902,7 +862,11 @@ impl<C: Compiler> AggregatedCompilerOutput<C> {
             if compiler_severity_filter.ge(&err.severity()) {
                 if compiler_severity_filter.is_warning() {
                     // skip ignored error codes and file path from warnings
-                    return self.has_warning(ignored_error_codes, ignored_file_paths);
+                    return self.has_warning(
+                        ignored_error_codes,
+                        ignored_file_paths,
+                        seismic_warnings_in_tests,
+                    );
                 }
                 return true;
             }
@@ -912,16 +876,27 @@ impl<C: Compiler> AggregatedCompilerOutput<C> {
 
     /// Checks if there are any compiler warnings that are not ignored by the specified error codes
     /// and file paths.
-    pub fn has_warning(&self, ignored_error_codes: &[u64], ignored_file_paths: &[PathBuf]) -> bool {
-        self.errors
-            .iter()
-            .any(|error| !self.should_ignore(ignored_error_codes, ignored_file_paths, error))
+    pub fn has_warning(
+        &self,
+        ignored_error_codes: &[u64],
+        ignored_file_paths: &[PathBuf],
+        seismic_warnings_in_tests: bool,
+    ) -> bool {
+        self.errors.iter().any(|error| {
+            !self.should_ignore(
+                ignored_error_codes,
+                ignored_file_paths,
+                seismic_warnings_in_tests,
+                error,
+            )
+        })
     }
 
     pub fn should_ignore(
         &self,
         ignored_error_codes: &[u64],
         ignored_file_paths: &[PathBuf],
+        seismic_warnings_in_tests: bool,
         error: &C::CompilationError,
     ) -> bool {
         if !error.is_warning() {
@@ -942,11 +917,11 @@ impl<C: Compiler> AggregatedCompilerOutput<C> {
                 // from a test file we skip
                 ignore |= self.is_test(path) && (code == 1878 || code == 5574);
 
-                // Suppress shielded literal warnings that are safe in test/script files.
-                // Constructor param (5500) and new-expression (5501–5505) warnings are
-                // NOT suppressed because those contracts ARE deployed on-chain.
-                ignore |= (self.is_test(path) || self.is_script(path))
-                    && SHIELDED_WARNINGS_SUPPRESSIBLE_IN_TESTS.contains(&code);
+                // Suppress all seismic warnings (code >= 10000) in test files,
+                // unless seismic_warnings_in_tests is set.
+                if !seismic_warnings_in_tests {
+                    ignore |= self.is_test(path) && code >= SEISMIC_WARNING_THRESHOLD;
+                }
             }
         }
 
@@ -990,6 +965,8 @@ pub struct OutputDiagnostics<'a, C: Compiler> {
     ignored_file_paths: &'a [PathBuf],
     /// set minimum level of severity that is treated as an error
     compiler_severity_filter: Severity,
+    /// When true, seismic warnings (code >= 10000) are shown even in test files.
+    seismic_warnings_in_tests: bool,
 }
 
 impl<C: Compiler> OutputDiagnostics<'_, C> {
@@ -999,12 +976,17 @@ impl<C: Compiler> OutputDiagnostics<'_, C> {
             self.ignored_error_codes,
             self.ignored_file_paths,
             &self.compiler_severity_filter,
+            self.seismic_warnings_in_tests,
         )
     }
 
     /// Returns true if there is at least one warning
     pub fn has_warning(&self) -> bool {
-        self.compiler_output.has_warning(self.ignored_error_codes, self.ignored_file_paths)
+        self.compiler_output.has_warning(
+            self.ignored_error_codes,
+            self.ignored_file_paths,
+            self.seismic_warnings_in_tests,
+        )
     }
 }
 
@@ -1023,6 +1005,7 @@ impl<C: Compiler> fmt::Display for OutputDiagnostics<'_, C> {
             if !self.compiler_output.should_ignore(
                 self.ignored_error_codes,
                 self.ignored_file_paths,
+                self.seismic_warnings_in_tests,
                 err,
             ) {
                 f.write_str("\n")?;
@@ -1088,172 +1071,52 @@ mod tests {
         MultiCompilerError::Solc(diag)
     }
 
-    /// Helper: returns true if the warning would be suppressed (ignored).
+    /// Helper: returns true if the warning would be suppressed (ignored) with default settings.
     fn is_suppressed(code: u64, file: &str) -> bool {
         let output = make_output();
         let warning = make_warning(code, file);
-        output.should_ignore(&[], &[], &warning)
+        output.should_ignore(&[], &[], false, &warning)
     }
 
-    // src/ files: nothing suppressed
-
-    #[test]
-    fn src_file_shows_all_warnings() {
-        // Constructor param
-        assert!(!is_suppressed(SHIELDED_CONSTRUCTOR_PARAM, "src/Foo.sol"));
-        // New-expression warnings (5501–5505)
-        assert!(!is_suppressed(SHIELDED_LITERAL_NEW_EXPR_INT, "src/Foo.sol"));
-        assert!(!is_suppressed(SHIELDED_LITERAL_NEW_EXPR_BOOL, "src/Foo.sol"));
-        assert!(!is_suppressed(SHIELDED_LITERAL_NEW_EXPR_ADDRESS, "src/Foo.sol"));
-        assert!(!is_suppressed(SHIELDED_LITERAL_NEW_EXPR_FIXEDBYTES, "src/Foo.sol"));
-        assert!(!is_suppressed(SHIELDED_LITERAL_NEW_EXPR_ENUM, "src/Foo.sol"));
-        // External call warnings (5506–5510)
-        assert!(!is_suppressed(SHIELDED_LITERAL_EXT_CALL_INT, "src/Foo.sol"));
-        assert!(!is_suppressed(SHIELDED_LITERAL_EXT_CALL_BOOL, "src/Foo.sol"));
-        assert!(!is_suppressed(SHIELDED_LITERAL_EXT_CALL_ADDRESS, "src/Foo.sol"));
-        assert!(!is_suppressed(SHIELDED_LITERAL_EXT_CALL_FIXEDBYTES, "src/Foo.sol"));
-        assert!(!is_suppressed(SHIELDED_LITERAL_EXT_CALL_ENUM, "src/Foo.sol"));
-        // Other context (9660–9663, 1457)
-        assert!(!is_suppressed(SHIELDED_LITERAL_OTHER_INT, "src/Foo.sol"));
-        assert!(!is_suppressed(SHIELDED_LITERAL_OTHER_BOOL, "src/Foo.sol"));
-        assert!(!is_suppressed(SHIELDED_LITERAL_OTHER_ADDRESS, "src/Foo.sol"));
-        assert!(!is_suppressed(SHIELDED_LITERAL_OTHER_FIXEDBYTES, "src/Foo.sol"));
-        assert!(!is_suppressed(SHIELDED_LITERAL_OTHER_ENUM, "src/Foo.sol"));
-    }
-
-    // test/ files
-
-    #[test]
-    fn test_file_shows_constructor_param_warning() {
-        assert!(!is_suppressed(SHIELDED_CONSTRUCTOR_PARAM, "test/Foo.t.sol"));
-    }
-
-    #[test]
-    fn test_file_shows_new_expr_warnings() {
-        assert!(!is_suppressed(SHIELDED_LITERAL_NEW_EXPR_INT, "test/Foo.t.sol"));
-        assert!(!is_suppressed(SHIELDED_LITERAL_NEW_EXPR_BOOL, "test/Foo.t.sol"));
-        assert!(!is_suppressed(SHIELDED_LITERAL_NEW_EXPR_ADDRESS, "test/Foo.t.sol"));
-        assert!(!is_suppressed(SHIELDED_LITERAL_NEW_EXPR_FIXEDBYTES, "test/Foo.t.sol"));
-        assert!(!is_suppressed(SHIELDED_LITERAL_NEW_EXPR_ENUM, "test/Foo.t.sol"));
-    }
-
-    #[test]
-    fn test_file_suppresses_ext_call_warnings() {
-        assert!(is_suppressed(SHIELDED_LITERAL_EXT_CALL_INT, "test/Foo.t.sol"));
-        assert!(is_suppressed(SHIELDED_LITERAL_EXT_CALL_BOOL, "test/Foo.t.sol"));
-        assert!(is_suppressed(SHIELDED_LITERAL_EXT_CALL_ADDRESS, "test/Foo.t.sol"));
-        assert!(is_suppressed(SHIELDED_LITERAL_EXT_CALL_FIXEDBYTES, "test/Foo.t.sol"));
-        assert!(is_suppressed(SHIELDED_LITERAL_EXT_CALL_ENUM, "test/Foo.t.sol"));
-    }
-
-    #[test]
-    fn test_file_suppresses_other_context_warnings() {
-        assert!(is_suppressed(SHIELDED_LITERAL_OTHER_INT, "test/Foo.t.sol"));
-        assert!(is_suppressed(SHIELDED_LITERAL_OTHER_BOOL, "test/Foo.t.sol"));
-        assert!(is_suppressed(SHIELDED_LITERAL_OTHER_ADDRESS, "test/Foo.t.sol"));
-        assert!(is_suppressed(SHIELDED_LITERAL_OTHER_FIXEDBYTES, "test/Foo.t.sol"));
-        assert!(is_suppressed(SHIELDED_LITERAL_OTHER_ENUM, "test/Foo.t.sol"));
-    }
-
-    // script/ files
-
-    #[test]
-    fn script_file_shows_constructor_param_warning() {
-        assert!(!is_suppressed(SHIELDED_CONSTRUCTOR_PARAM, "script/Deploy.s.sol"));
-    }
-
-    #[test]
-    fn script_file_shows_new_expr_warnings() {
-        assert!(!is_suppressed(SHIELDED_LITERAL_NEW_EXPR_INT, "script/Deploy.s.sol"));
-        assert!(!is_suppressed(SHIELDED_LITERAL_NEW_EXPR_BOOL, "script/Deploy.s.sol"));
-        assert!(!is_suppressed(SHIELDED_LITERAL_NEW_EXPR_ADDRESS, "script/Deploy.s.sol"));
-        assert!(!is_suppressed(SHIELDED_LITERAL_NEW_EXPR_FIXEDBYTES, "script/Deploy.s.sol"));
-        assert!(!is_suppressed(SHIELDED_LITERAL_NEW_EXPR_ENUM, "script/Deploy.s.sol"));
-    }
-
-    #[test]
-    fn script_file_suppresses_ext_call_warnings() {
-        assert!(is_suppressed(SHIELDED_LITERAL_EXT_CALL_INT, "script/Deploy.s.sol"));
-        assert!(is_suppressed(SHIELDED_LITERAL_EXT_CALL_BOOL, "script/Deploy.s.sol"));
-        assert!(is_suppressed(SHIELDED_LITERAL_EXT_CALL_ADDRESS, "script/Deploy.s.sol"));
-        assert!(is_suppressed(SHIELDED_LITERAL_EXT_CALL_FIXEDBYTES, "script/Deploy.s.sol"));
-        assert!(is_suppressed(SHIELDED_LITERAL_EXT_CALL_ENUM, "script/Deploy.s.sol"));
-    }
-
-    #[test]
-    fn script_file_suppresses_other_context_warnings() {
-        assert!(is_suppressed(SHIELDED_LITERAL_OTHER_INT, "script/Deploy.s.sol"));
-        assert!(is_suppressed(SHIELDED_LITERAL_OTHER_BOOL, "script/Deploy.s.sol"));
-        assert!(is_suppressed(SHIELDED_LITERAL_OTHER_ADDRESS, "script/Deploy.s.sol"));
-        assert!(is_suppressed(SHIELDED_LITERAL_OTHER_FIXEDBYTES, "script/Deploy.s.sol"));
-        assert!(is_suppressed(SHIELDED_LITERAL_OTHER_ENUM, "script/Deploy.s.sol"));
-    }
-
-    // scripts/ directory variant
-
-    #[test]
-    fn scripts_dir_suppresses_same_as_script() {
-        assert!(is_suppressed(SHIELDED_LITERAL_EXT_CALL_INT, "scripts/Deploy.s.sol"));
-        assert!(is_suppressed(SHIELDED_LITERAL_OTHER_INT, "scripts/Deploy.s.sol"));
-        assert!(!is_suppressed(SHIELDED_CONSTRUCTOR_PARAM, "scripts/Deploy.s.sol"));
-        assert!(!is_suppressed(SHIELDED_LITERAL_NEW_EXPR_INT, "scripts/Deploy.s.sol"));
-    }
-
-    // lib/ and other paths: no suppression
-
-    #[test]
-    fn lib_file_shows_all_warnings() {
-        assert!(!is_suppressed(SHIELDED_CONSTRUCTOR_PARAM, "lib/Dep.sol"));
-        assert!(!is_suppressed(SHIELDED_LITERAL_NEW_EXPR_INT, "lib/Dep.sol"));
-        assert!(!is_suppressed(SHIELDED_LITERAL_EXT_CALL_INT, "lib/Dep.sol"));
-        assert!(!is_suppressed(SHIELDED_LITERAL_OTHER_INT, "lib/Dep.sol"));
-        assert!(!is_suppressed(SHIELDED_LITERAL_OTHER_ENUM, "lib/Dep.sol"));
-    }
-
-    // non-warning errors are never suppressed
-
-    #[test]
-    fn errors_are_never_suppressed() {
+    /// Helper: returns true if the warning would be suppressed with the given flag.
+    fn is_suppressed_with_flag(code: u64, file: &str, seismic_warnings_in_tests: bool) -> bool {
         let output = make_output();
-        let error = make_error(SHIELDED_LITERAL_OTHER_INT, "test/Foo.t.sol");
-        assert!(!output.should_ignore(&[], &[], &error));
-    }
-
-    // constant values are correct
-
-    #[test]
-    fn constant_values_match_spec() {
-        assert_eq!(SHIELDED_CONSTRUCTOR_PARAM, 5500);
-        assert_eq!(SHIELDED_LITERAL_NEW_EXPR_INT, 5501);
-        assert_eq!(SHIELDED_LITERAL_NEW_EXPR_BOOL, 5502);
-        assert_eq!(SHIELDED_LITERAL_NEW_EXPR_ADDRESS, 5503);
-        assert_eq!(SHIELDED_LITERAL_NEW_EXPR_FIXEDBYTES, 5504);
-        assert_eq!(SHIELDED_LITERAL_NEW_EXPR_ENUM, 5505);
-        assert_eq!(SHIELDED_LITERAL_EXT_CALL_INT, 5506);
-        assert_eq!(SHIELDED_LITERAL_EXT_CALL_BOOL, 5507);
-        assert_eq!(SHIELDED_LITERAL_EXT_CALL_ADDRESS, 5508);
-        assert_eq!(SHIELDED_LITERAL_EXT_CALL_FIXEDBYTES, 5509);
-        assert_eq!(SHIELDED_LITERAL_EXT_CALL_ENUM, 5510);
-        assert_eq!(SHIELDED_LITERAL_OTHER_INT, 9660);
-        assert_eq!(SHIELDED_LITERAL_OTHER_BOOL, 9661);
-        assert_eq!(SHIELDED_LITERAL_OTHER_ADDRESS, 9662);
-        assert_eq!(SHIELDED_LITERAL_OTHER_FIXEDBYTES, 9663);
-        assert_eq!(SHIELDED_LITERAL_OTHER_ENUM, 1457);
+        let warning = make_warning(code, file);
+        output.should_ignore(&[], &[], seismic_warnings_in_tests, &warning)
     }
 
     #[test]
-    fn suppressible_collection_has_correct_entries() {
-        // Should contain ext call + other context = 10 entries
-        assert_eq!(SHIELDED_WARNINGS_SUPPRESSIBLE_IN_TESTS.len(), 10);
-        // Should NOT contain constructor param or new-expression warnings
-        assert!(!SHIELDED_WARNINGS_SUPPRESSIBLE_IN_TESTS.contains(&SHIELDED_CONSTRUCTOR_PARAM));
-        assert!(!SHIELDED_WARNINGS_SUPPRESSIBLE_IN_TESTS.contains(&SHIELDED_LITERAL_NEW_EXPR_INT));
-        assert!(!SHIELDED_WARNINGS_SUPPRESSIBLE_IN_TESTS.contains(&SHIELDED_LITERAL_NEW_EXPR_BOOL));
-        assert!(
-            !SHIELDED_WARNINGS_SUPPRESSIBLE_IN_TESTS.contains(&SHIELDED_LITERAL_NEW_EXPR_ADDRESS)
-        );
-        assert!(!SHIELDED_WARNINGS_SUPPRESSIBLE_IN_TESTS
-            .contains(&SHIELDED_LITERAL_NEW_EXPR_FIXEDBYTES));
-        assert!(!SHIELDED_WARNINGS_SUPPRESSIBLE_IN_TESTS.contains(&SHIELDED_LITERAL_NEW_EXPR_ENUM));
+    fn seismic_warnings_suppressed_in_test_files() {
+        assert!(is_suppressed(10001, "test/Foo.t.sol"));
+        assert!(is_suppressed(15000, "test/Foo.t.sol"));
+    }
+
+    #[test]
+    fn seismic_warnings_shown_in_src_files() {
+        assert!(!is_suppressed(10001, "src/Foo.sol"));
+    }
+
+    #[test]
+    fn seismic_warnings_shown_in_script_files() {
+        assert!(!is_suppressed(10001, "script/Deploy.s.sol"));
+        assert!(!is_suppressed(10001, "scripts/Deploy.s.sol"));
+    }
+
+    #[test]
+    fn seismic_warnings_shown_in_test_when_flag_set() {
+        assert!(!is_suppressed_with_flag(10001, "test/Foo.t.sol", true));
+    }
+
+    #[test]
+    fn non_seismic_warnings_not_suppressed() {
+        assert!(!is_suppressed(9999, "test/Foo.t.sol"));
+        assert!(!is_suppressed(5000, "src/Foo.sol"));
+    }
+
+    #[test]
+    fn errors_never_suppressed() {
+        let output = make_output();
+        let error = make_error(10001, "test/Foo.t.sol");
+        assert!(!output.should_ignore(&[], &[], false, &error));
     }
 }

--- a/crates/compilers/src/compile/project.rs
+++ b/crates/compilers/src/compile/project.rs
@@ -322,6 +322,7 @@ impl<'a, T: ArtifactOutput<CompilerContract = C::CompilerContract>, C: Compiler>
             &project.ignored_file_paths,
             &project.compiler_severity_filter,
             project.seismic_warnings_in_tests,
+            project.no_seismic_warnings,
         ) {
             trace!("skip writing cache file due to solc errors: {:?}", output.errors);
             project.artifacts_handler().output_to_artifacts(
@@ -378,11 +379,13 @@ impl<T: ArtifactOutput<CompilerContract = C::CompilerContract>, C: Compiler>
         let ignored_file_paths = project.ignored_file_paths.clone();
         let compiler_severity_filter = project.compiler_severity_filter;
         let seismic_warnings_in_tests = project.seismic_warnings_in_tests;
+        let no_seismic_warnings = project.no_seismic_warnings;
         let has_error = output.has_error(
             &ignored_error_codes,
             &ignored_file_paths,
             &compiler_severity_filter,
             seismic_warnings_in_tests,
+            no_seismic_warnings,
         );
         let skip_write_to_disk = project.no_artifacts || has_error;
         trace!(has_error, project.no_artifacts, skip_write_to_disk, cache_path=?project.cache_path(),"prepare writing cache file");
@@ -409,6 +412,7 @@ impl<T: ArtifactOutput<CompilerContract = C::CompilerContract>, C: Compiler>
             ignored_error_codes,
             ignored_file_paths,
             seismic_warnings_in_tests,
+            no_seismic_warnings,
             compiler_severity_filter,
             builds,
             edges,

--- a/crates/compilers/src/compile/project.rs
+++ b/crates/compilers/src/compile/project.rs
@@ -321,6 +321,7 @@ impl<'a, T: ArtifactOutput<CompilerContract = C::CompilerContract>, C: Compiler>
             &project.ignored_error_codes,
             &project.ignored_file_paths,
             &project.compiler_severity_filter,
+            project.seismic_warnings_in_tests,
         ) {
             trace!("skip writing cache file due to solc errors: {:?}", output.errors);
             project.artifacts_handler().output_to_artifacts(
@@ -376,8 +377,13 @@ impl<T: ArtifactOutput<CompilerContract = C::CompilerContract>, C: Compiler>
         let ignored_error_codes = project.ignored_error_codes.clone();
         let ignored_file_paths = project.ignored_file_paths.clone();
         let compiler_severity_filter = project.compiler_severity_filter;
-        let has_error =
-            output.has_error(&ignored_error_codes, &ignored_file_paths, &compiler_severity_filter);
+        let seismic_warnings_in_tests = project.seismic_warnings_in_tests;
+        let has_error = output.has_error(
+            &ignored_error_codes,
+            &ignored_file_paths,
+            &compiler_severity_filter,
+            seismic_warnings_in_tests,
+        );
         let skip_write_to_disk = project.no_artifacts || has_error;
         trace!(has_error, project.no_artifacts, skip_write_to_disk, cache_path=?project.cache_path(),"prepare writing cache file");
 
@@ -402,6 +408,7 @@ impl<T: ArtifactOutput<CompilerContract = C::CompilerContract>, C: Compiler>
             cached_artifacts,
             ignored_error_codes,
             ignored_file_paths,
+            seismic_warnings_in_tests,
             compiler_severity_filter,
             builds,
             edges,

--- a/crates/compilers/src/compilers/solc/mod.rs
+++ b/crates/compilers/src/compilers/solc/mod.rs
@@ -178,6 +178,9 @@ pub struct CliSettings {
     pub base_path: Option<PathBuf>,
     #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
     pub include_paths: BTreeSet<PathBuf>,
+    /// When true, show seismic warnings (code >= 10000) even in test files.
+    #[serde(default)]
+    pub seismic_warnings_in_tests: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]

--- a/crates/compilers/src/compilers/solc/mod.rs
+++ b/crates/compilers/src/compilers/solc/mod.rs
@@ -181,6 +181,9 @@ pub struct CliSettings {
     /// When true, show seismic warnings (code >= 10000) even in test files.
     #[serde(default)]
     pub seismic_warnings_in_tests: bool,
+    /// When true, suppress ALL seismic warnings (code >= 10000) globally.
+    #[serde(default)]
+    pub no_seismic_warnings: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]

--- a/crates/compilers/src/lib.rs
+++ b/crates/compilers/src/lib.rs
@@ -112,6 +112,8 @@ pub struct Project<
     pub compiler_severity_filter: Severity,
     /// When true, seismic warnings (code >= 10000) are shown even in test files.
     pub seismic_warnings_in_tests: bool,
+    /// When true, suppress ALL seismic warnings (code >= 10000) globally.
+    pub no_seismic_warnings: bool,
     /// Maximum number of `solc` processes to run simultaneously.
     solc_jobs: usize,
     /// Offline mode, if set, network access (download solc) is disallowed
@@ -471,6 +473,8 @@ pub struct ProjectBuilder<
     compiler_severity_filter: Severity,
     /// When true, seismic warnings (code >= 10000) are shown even in test files.
     seismic_warnings_in_tests: bool,
+    /// When true, suppress ALL seismic warnings (code >= 10000) globally.
+    no_seismic_warnings: bool,
     solc_jobs: Option<usize>,
     /// Optional sparse output filter used to optimize compilation.
     sparse_output: Option<Box<dyn FileFilter>>,
@@ -491,6 +495,7 @@ impl<C: Compiler, T: ArtifactOutput<CompilerContract = C::CompilerContract>> Pro
             ignored_file_paths: Vec::new(),
             compiler_severity_filter: Severity::Error,
             seismic_warnings_in_tests: false,
+            no_seismic_warnings: false,
             solc_jobs: None,
             settings: None,
             sparse_output: None,
@@ -540,6 +545,13 @@ impl<C: Compiler, T: ArtifactOutput<CompilerContract = C::CompilerContract>> Pro
     #[must_use]
     pub fn set_seismic_warnings_in_tests(mut self, seismic_warnings_in_tests: bool) -> Self {
         self.seismic_warnings_in_tests = seismic_warnings_in_tests;
+        self
+    }
+
+    /// When true, suppress ALL seismic warnings (code >= 10000) globally.
+    #[must_use]
+    pub fn set_no_seismic_warnings(mut self, no_seismic_warnings: bool) -> Self {
+        self.no_seismic_warnings = no_seismic_warnings;
         self
     }
 
@@ -657,6 +669,7 @@ impl<C: Compiler, T: ArtifactOutput<CompilerContract = C::CompilerContract>> Pro
             ignored_error_codes,
             compiler_severity_filter,
             seismic_warnings_in_tests,
+            no_seismic_warnings,
             solc_jobs,
             offline,
             build_info,
@@ -681,6 +694,7 @@ impl<C: Compiler, T: ArtifactOutput<CompilerContract = C::CompilerContract>> Pro
             ignored_file_paths,
             compiler_severity_filter,
             seismic_warnings_in_tests,
+            no_seismic_warnings,
             solc_jobs,
             build_info,
             settings,
@@ -698,6 +712,7 @@ impl<C: Compiler, T: ArtifactOutput<CompilerContract = C::CompilerContract>> Pro
             ignored_file_paths,
             compiler_severity_filter,
             seismic_warnings_in_tests,
+            no_seismic_warnings,
             solc_jobs,
             offline,
             build_info,
@@ -726,6 +741,7 @@ impl<C: Compiler, T: ArtifactOutput<CompilerContract = C::CompilerContract>> Pro
             ignored_file_paths,
             compiler_severity_filter,
             seismic_warnings_in_tests,
+            no_seismic_warnings,
             solc_jobs: solc_jobs
                 .or_else(|| std::thread::available_parallelism().ok().map(|n| n.get()))
                 .unwrap_or(1),

--- a/crates/compilers/src/lib.rs
+++ b/crates/compilers/src/lib.rs
@@ -110,6 +110,8 @@ pub struct Project<
     pub ignored_file_paths: Vec<PathBuf>,
     /// The minimum severity level that is treated as a compiler error
     pub compiler_severity_filter: Severity,
+    /// When true, seismic warnings (code >= 10000) are shown even in test files.
+    pub seismic_warnings_in_tests: bool,
     /// Maximum number of `solc` processes to run simultaneously.
     solc_jobs: usize,
     /// Offline mode, if set, network access (download solc) is disallowed
@@ -467,6 +469,8 @@ pub struct ProjectBuilder<
     pub ignored_file_paths: Vec<PathBuf>,
     /// The minimum severity level that is treated as a compiler error
     compiler_severity_filter: Severity,
+    /// When true, seismic warnings (code >= 10000) are shown even in test files.
+    seismic_warnings_in_tests: bool,
     solc_jobs: Option<usize>,
     /// Optional sparse output filter used to optimize compilation.
     sparse_output: Option<Box<dyn FileFilter>>,
@@ -486,6 +490,7 @@ impl<C: Compiler, T: ArtifactOutput<CompilerContract = C::CompilerContract>> Pro
             ignored_error_codes: Vec::new(),
             ignored_file_paths: Vec::new(),
             compiler_severity_filter: Severity::Error,
+            seismic_warnings_in_tests: false,
             solc_jobs: None,
             settings: None,
             sparse_output: None,
@@ -528,6 +533,13 @@ impl<C: Compiler, T: ArtifactOutput<CompilerContract = C::CompilerContract>> Pro
     #[must_use]
     pub fn set_compiler_severity_filter(mut self, compiler_severity_filter: Severity) -> Self {
         self.compiler_severity_filter = compiler_severity_filter;
+        self
+    }
+
+    /// When true, seismic warnings (code >= 10000) are shown even in test files.
+    #[must_use]
+    pub fn set_seismic_warnings_in_tests(mut self, seismic_warnings_in_tests: bool) -> Self {
+        self.seismic_warnings_in_tests = seismic_warnings_in_tests;
         self
     }
 
@@ -644,6 +656,7 @@ impl<C: Compiler, T: ArtifactOutput<CompilerContract = C::CompilerContract>> Pro
             no_artifacts,
             ignored_error_codes,
             compiler_severity_filter,
+            seismic_warnings_in_tests,
             solc_jobs,
             offline,
             build_info,
@@ -667,6 +680,7 @@ impl<C: Compiler, T: ArtifactOutput<CompilerContract = C::CompilerContract>> Pro
             ignored_error_codes,
             ignored_file_paths,
             compiler_severity_filter,
+            seismic_warnings_in_tests,
             solc_jobs,
             build_info,
             settings,
@@ -683,6 +697,7 @@ impl<C: Compiler, T: ArtifactOutput<CompilerContract = C::CompilerContract>> Pro
             ignored_error_codes,
             ignored_file_paths,
             compiler_severity_filter,
+            seismic_warnings_in_tests,
             solc_jobs,
             offline,
             build_info,
@@ -710,6 +725,7 @@ impl<C: Compiler, T: ArtifactOutput<CompilerContract = C::CompilerContract>> Pro
             ignored_error_codes,
             ignored_file_paths,
             compiler_severity_filter,
+            seismic_warnings_in_tests,
             solc_jobs: solc_jobs
                 .or_else(|| std::thread::available_parallelism().ok().map(|n| n.get()))
                 .unwrap_or(1),

--- a/crates/compilers/tests/project.rs
+++ b/crates/compilers/tests/project.rs
@@ -2205,7 +2205,7 @@ fn test_severity_warnings() {
     tmp.add_source("A", content).unwrap();
 
     let out = tmp.compile().unwrap();
-    assert!(out.output().has_error(&[], &[], &Severity::Warning));
+    assert!(out.output().has_error(&[], &[], &Severity::Warning, false));
 
     let content = r"
     // SPDX-License-Identifier: MIT OR Apache-2.0
@@ -2215,7 +2215,7 @@ fn test_severity_warnings() {
     tmp.add_source("A", content).unwrap();
 
     let out = tmp.compile().unwrap();
-    assert!(!out.output().has_error(&[], &[], &Severity::Warning));
+    assert!(!out.output().has_error(&[], &[], &Severity::Warning, false));
 
     let content = r"
     // SPDX-License-Identifier: MIT OR Apache-2.0
@@ -2229,7 +2229,7 @@ fn test_severity_warnings() {
     tmp.add_source("A", content).unwrap();
 
     let out = tmp.compile().unwrap();
-    assert!(out.output().has_error(&[], &[], &Severity::Warning));
+    assert!(out.output().has_error(&[], &[], &Severity::Warning, false));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Suppress all seismic warnings (code >= 10000) in test files by default, configurable via `seismic_warnings_in_tests`
- Add `no_seismic_warnings` flag to suppress ALL seismic warnings globally (src, test, and script files)
- Both flags are threaded through `CliSettings`, `Project`, `ProjectBuilder`, `ProjectCompileOutput`, and `should_ignore()`

## Context
Companion PR to SeismicSystems/seismic-foundry#180 — foundry passes these config values from `foundry.toml` through to seismic-compilers.

## Test plan
- [x] Unit tests for `should_ignore()` threshold behavior (10 tests covering both flags)
- [ ] Integration: merge foundry PR #180 and verify `sforge build` suppresses warnings in test files