### PR TITLE
feat: add seismic warning config flags

### DIFF
--- a/crates/compilers/src/compile/output/mod.rs
+++ b/crates/compilers/src/compile/output/mod.rs
@@ -8,39 +8,39 @@
 /// CREATE/CREATE2 does not encrypt calldata, so values leak in deployment tx.
 /// Not suppressed in any context — always relevant.
 #[cfg(test)]
-const SHIELDED_CONSTRUCTOR_PARAM: u64 = 5500;
+const SHIELDED_CONSTRUCTOR_PARAM: u64 = 10103;
 
 /// Shielded literal warnings: literal inside `new(...)` expression args.
 /// Child contract is deployed via CREATE — literal leaks in init code.
 /// Not suppressed in any context — always relevant.
 #[cfg(test)]
-const SHIELDED_LITERAL_NEW_EXPR_INT: u64 = 5501;
+const SHIELDED_LITERAL_NEW_EXPR_INT: u64 = 10401;
 #[cfg(test)]
-const SHIELDED_LITERAL_NEW_EXPR_BOOL: u64 = 5502;
+const SHIELDED_LITERAL_NEW_EXPR_BOOL: u64 = 10404;
 #[cfg(test)]
-const SHIELDED_LITERAL_NEW_EXPR_ADDRESS: u64 = 5503;
+const SHIELDED_LITERAL_NEW_EXPR_ADDRESS: u64 = 10407;
 #[cfg(test)]
-const SHIELDED_LITERAL_NEW_EXPR_FIXEDBYTES: u64 = 5504;
+const SHIELDED_LITERAL_NEW_EXPR_FIXEDBYTES: u64 = 10410;
 #[cfg(test)]
-const SHIELDED_LITERAL_NEW_EXPR_ENUM: u64 = 5505;
+const SHIELDED_LITERAL_NEW_EXPR_ENUM: u64 = 10413;
 
 /// Shielded literal warnings: literal inside external call args.
 /// Literal is in caller bytecode, but calldata is encrypted by TxSeismic.
 /// Safe to suppress in test/script files.
-const SHIELDED_LITERAL_EXT_CALL_INT: u64 = 5506;
-const SHIELDED_LITERAL_EXT_CALL_BOOL: u64 = 5507;
-const SHIELDED_LITERAL_EXT_CALL_ADDRESS: u64 = 5508;
-const SHIELDED_LITERAL_EXT_CALL_FIXEDBYTES: u64 = 5509;
-const SHIELDED_LITERAL_EXT_CALL_ENUM: u64 = 5510;
+const SHIELDED_LITERAL_EXT_CALL_INT: u64 = 10402;
+const SHIELDED_LITERAL_EXT_CALL_BOOL: u64 = 10405;
+const SHIELDED_LITERAL_EXT_CALL_ADDRESS: u64 = 10408;
+const SHIELDED_LITERAL_EXT_CALL_FIXEDBYTES: u64 = 10411;
+const SHIELDED_LITERAL_EXT_CALL_ENUM: u64 = 10414;
 
 /// Shielded literal warnings: literal in other contexts (assignments, internal calls, etc.).
 /// Literal is embedded in contract bytecode.
 /// Safe to suppress in test/script files where bytecode is never deployed.
-const SHIELDED_LITERAL_OTHER_INT: u64 = 9660;
-const SHIELDED_LITERAL_OTHER_BOOL: u64 = 9661;
-const SHIELDED_LITERAL_OTHER_ADDRESS: u64 = 9662;
-const SHIELDED_LITERAL_OTHER_FIXEDBYTES: u64 = 9663;
-const SHIELDED_LITERAL_OTHER_ENUM: u64 = 1457;
+const SHIELDED_LITERAL_OTHER_INT: u64 = 10403;
+const SHIELDED_LITERAL_OTHER_BOOL: u64 = 10406;
+const SHIELDED_LITERAL_OTHER_ADDRESS: u64 = 10409;
+const SHIELDED_LITERAL_OTHER_FIXEDBYTES: u64 = 10412;
+const SHIELDED_LITERAL_OTHER_ENUM: u64 = 10415;
 
 /// Warnings suppressed in test/script files — bytecode never deployed, calldata encrypted.
 const SHIELDED_WARNINGS_SUPPRESSIBLE_IN_TESTS: &[u64] = &[
@@ -943,8 +943,9 @@ impl<C: Compiler> AggregatedCompilerOutput<C> {
                 ignore |= self.is_test(path) && (code == 1878 || code == 5574);
 
                 // Suppress shielded literal warnings that are safe in test/script files.
-                // Constructor param (5500) and new-expression (5501–5505) warnings are
-                // NOT suppressed because those contracts ARE deployed on-chain.
+                // Constructor param (10103) and new-expression (10401,10404,10407,10410,10413)
+                // warnings are NOT suppressed because those contracts ARE deployed
+                // on-chain.
                 ignore |= (self.is_test(path) || self.is_script(path))
                     && SHIELDED_WARNINGS_SUPPRESSIBLE_IN_TESTS.contains(&code);
             }
@@ -1101,13 +1102,13 @@ mod tests {
     fn src_file_shows_all_warnings() {
         // Constructor param
         assert!(!is_suppressed(SHIELDED_CONSTRUCTOR_PARAM, "src/Foo.sol"));
-        // New-expression warnings (5501–5505)
+        // New-expression warnings (10401,10404,10407,10410,10413)
         assert!(!is_suppressed(SHIELDED_LITERAL_NEW_EXPR_INT, "src/Foo.sol"));
         assert!(!is_suppressed(SHIELDED_LITERAL_NEW_EXPR_BOOL, "src/Foo.sol"));
         assert!(!is_suppressed(SHIELDED_LITERAL_NEW_EXPR_ADDRESS, "src/Foo.sol"));
         assert!(!is_suppressed(SHIELDED_LITERAL_NEW_EXPR_FIXEDBYTES, "src/Foo.sol"));
         assert!(!is_suppressed(SHIELDED_LITERAL_NEW_EXPR_ENUM, "src/Foo.sol"));
-        // External call warnings (5506–5510)
+        // External call warnings (10402,10405,10408,10411,10414)
         assert!(!is_suppressed(SHIELDED_LITERAL_EXT_CALL_INT, "src/Foo.sol"));
         assert!(!is_suppressed(SHIELDED_LITERAL_EXT_CALL_BOOL, "src/Foo.sol"));
         assert!(!is_suppressed(SHIELDED_LITERAL_EXT_CALL_ADDRESS, "src/Foo.sol"));
@@ -1223,22 +1224,22 @@ mod tests {
 
     #[test]
     fn constant_values_match_spec() {
-        assert_eq!(SHIELDED_CONSTRUCTOR_PARAM, 5500);
-        assert_eq!(SHIELDED_LITERAL_NEW_EXPR_INT, 5501);
-        assert_eq!(SHIELDED_LITERAL_NEW_EXPR_BOOL, 5502);
-        assert_eq!(SHIELDED_LITERAL_NEW_EXPR_ADDRESS, 5503);
-        assert_eq!(SHIELDED_LITERAL_NEW_EXPR_FIXEDBYTES, 5504);
-        assert_eq!(SHIELDED_LITERAL_NEW_EXPR_ENUM, 5505);
-        assert_eq!(SHIELDED_LITERAL_EXT_CALL_INT, 5506);
-        assert_eq!(SHIELDED_LITERAL_EXT_CALL_BOOL, 5507);
-        assert_eq!(SHIELDED_LITERAL_EXT_CALL_ADDRESS, 5508);
-        assert_eq!(SHIELDED_LITERAL_EXT_CALL_FIXEDBYTES, 5509);
-        assert_eq!(SHIELDED_LITERAL_EXT_CALL_ENUM, 5510);
-        assert_eq!(SHIELDED_LITERAL_OTHER_INT, 9660);
-        assert_eq!(SHIELDED_LITERAL_OTHER_BOOL, 9661);
-        assert_eq!(SHIELDED_LITERAL_OTHER_ADDRESS, 9662);
-        assert_eq!(SHIELDED_LITERAL_OTHER_FIXEDBYTES, 9663);
-        assert_eq!(SHIELDED_LITERAL_OTHER_ENUM, 1457);
+        assert_eq!(SHIELDED_CONSTRUCTOR_PARAM, 10103);
+        assert_eq!(SHIELDED_LITERAL_NEW_EXPR_INT, 10401);
+        assert_eq!(SHIELDED_LITERAL_NEW_EXPR_BOOL, 10404);
+        assert_eq!(SHIELDED_LITERAL_NEW_EXPR_ADDRESS, 10407);
+        assert_eq!(SHIELDED_LITERAL_NEW_EXPR_FIXEDBYTES, 10410);
+        assert_eq!(SHIELDED_LITERAL_NEW_EXPR_ENUM, 10413);
+        assert_eq!(SHIELDED_LITERAL_EXT_CALL_INT, 10402);
+        assert_eq!(SHIELDED_LITERAL_EXT_CALL_BOOL, 10405);
+        assert_eq!(SHIELDED_LITERAL_EXT_CALL_ADDRESS, 10408);
+        assert_eq!(SHIELDED_LITERAL_EXT_CALL_FIXEDBYTES, 10411);
+        assert_eq!(SHIELDED_LITERAL_EXT_CALL_ENUM, 10414);
+        assert_eq!(SHIELDED_LITERAL_OTHER_INT, 10403);
+        assert_eq!(SHIELDED_LITERAL_OTHER_BOOL, 10406);
+        assert_eq!(SHIELDED_LITERAL_OTHER_ADDRESS, 10409);
+        assert_eq!(SHIELDED_LITERAL_OTHER_FIXEDBYTES, 10412);
+        assert_eq!(SHIELDED_LITERAL_OTHER_ENUM, 10415);
     }
 
     #[test]

--- a/crates/compilers/src/compile/output/mod.rs
+++ b/crates/compilers/src/compile/output/mod.rs
@@ -42,6 +42,9 @@ const SHIELDED_LITERAL_OTHER_ADDRESS: u64 = 10409;
 const SHIELDED_LITERAL_OTHER_FIXEDBYTES: u64 = 10412;
 const SHIELDED_LITERAL_OTHER_ENUM: u64 = 10415;
 
+/// Threshold above which a warning code is considered a seismic warning.
+const SEISMIC_WARNING_THRESHOLD: u64 = 10000;
+
 /// Warnings suppressed in test/script files — bytecode never deployed, calldata encrypted.
 const SHIELDED_WARNINGS_SUPPRESSIBLE_IN_TESTS: &[u64] = &[
     // External call context
@@ -139,6 +142,10 @@ pub struct ProjectCompileOutput<
     pub(crate) ignored_file_paths: Vec<PathBuf>,
     /// set minimum level of severity that is treated as an error
     pub(crate) compiler_severity_filter: Severity,
+    /// When true, show seismic warnings (code >= 10000) even in test files.
+    pub(crate) seismic_warnings_in_tests: bool,
+    /// When true, suppress ALL seismic warnings (code >= 10000) globally.
+    pub(crate) no_seismic_warnings: bool,
     /// all build infos that were just compiled
     pub(crate) builds: Builds<C::Language>,
     /// The relationship between the source files and their imports
@@ -548,12 +555,19 @@ impl<C: Compiler, T: ArtifactOutput<CompilerContract = C::CompilerContract>>
             &self.ignored_error_codes,
             &self.ignored_file_paths,
             &self.compiler_severity_filter,
+            self.seismic_warnings_in_tests,
+            self.no_seismic_warnings,
         )
     }
 
     /// Returns whether any warnings were emitted by the compiler.
     pub fn has_compiler_warnings(&self) -> bool {
-        self.compiler_output.has_warning(&self.ignored_error_codes, &self.ignored_file_paths)
+        self.compiler_output.has_warning(
+            &self.ignored_error_codes,
+            &self.ignored_file_paths,
+            self.seismic_warnings_in_tests,
+            self.no_seismic_warnings,
+        )
     }
 
     /// Panics if any errors were emitted by the compiler.
@@ -582,6 +596,8 @@ impl<C: Compiler, T: ArtifactOutput<CompilerContract = C::CompilerContract>> fmt
                     &self.ignored_error_codes,
                     &self.ignored_file_paths,
                     self.compiler_severity_filter,
+                    self.seismic_warnings_in_tests,
+                    self.no_seismic_warnings,
                 )
                 .fmt(f)
         }
@@ -626,12 +642,16 @@ impl<C: Compiler> AggregatedCompilerOutput<C> {
         ignored_error_codes: &'a [u64],
         ignored_file_paths: &'a [PathBuf],
         compiler_severity_filter: Severity,
+        seismic_warnings_in_tests: bool,
+        no_seismic_warnings: bool,
     ) -> OutputDiagnostics<'a, C> {
         OutputDiagnostics {
             compiler_output: self,
             ignored_error_codes,
             ignored_file_paths,
             compiler_severity_filter,
+            seismic_warnings_in_tests,
+            no_seismic_warnings,
         }
     }
 
@@ -892,6 +912,8 @@ impl<C: Compiler> AggregatedCompilerOutput<C> {
         ignored_error_codes: &[u64],
         ignored_file_paths: &[PathBuf],
         compiler_severity_filter: &Severity,
+        seismic_warnings_in_tests: bool,
+        no_seismic_warnings: bool,
     ) -> bool {
         self.errors.iter().any(|err| {
             if err.is_error() {
@@ -902,7 +924,12 @@ impl<C: Compiler> AggregatedCompilerOutput<C> {
             if compiler_severity_filter.ge(&err.severity()) {
                 if compiler_severity_filter.is_warning() {
                     // skip ignored error codes and file path from warnings
-                    return self.has_warning(ignored_error_codes, ignored_file_paths);
+                    return self.has_warning(
+                        ignored_error_codes,
+                        ignored_file_paths,
+                        seismic_warnings_in_tests,
+                        no_seismic_warnings,
+                    );
                 }
                 return true;
             }
@@ -912,10 +939,22 @@ impl<C: Compiler> AggregatedCompilerOutput<C> {
 
     /// Checks if there are any compiler warnings that are not ignored by the specified error codes
     /// and file paths.
-    pub fn has_warning(&self, ignored_error_codes: &[u64], ignored_file_paths: &[PathBuf]) -> bool {
-        self.errors
-            .iter()
-            .any(|error| !self.should_ignore(ignored_error_codes, ignored_file_paths, error))
+    pub fn has_warning(
+        &self,
+        ignored_error_codes: &[u64],
+        ignored_file_paths: &[PathBuf],
+        seismic_warnings_in_tests: bool,
+        no_seismic_warnings: bool,
+    ) -> bool {
+        self.errors.iter().any(|error| {
+            !self.should_ignore(
+                ignored_error_codes,
+                ignored_file_paths,
+                error,
+                seismic_warnings_in_tests,
+                no_seismic_warnings,
+            )
+        })
     }
 
     pub fn should_ignore(
@@ -923,6 +962,8 @@ impl<C: Compiler> AggregatedCompilerOutput<C> {
         ignored_error_codes: &[u64],
         ignored_file_paths: &[PathBuf],
         error: &C::CompilationError,
+        seismic_warnings_in_tests: bool,
+        no_seismic_warnings: bool,
     ) -> bool {
         if !error.is_warning() {
             return false;
@@ -931,6 +972,11 @@ impl<C: Compiler> AggregatedCompilerOutput<C> {
         let mut ignore = false;
 
         if let Some(code) = error.error_code() {
+            // If no_seismic_warnings is set, suppress ALL seismic warnings globally.
+            if no_seismic_warnings && code >= SEISMIC_WARNING_THRESHOLD {
+                return true;
+            }
+
             ignore |= ignored_error_codes.contains(&code);
             if let Some(loc) = error.source_location() {
                 let path = Path::new(&loc.file);
@@ -946,8 +992,15 @@ impl<C: Compiler> AggregatedCompilerOutput<C> {
                 // Constructor param (10103) and new-expression (10401,10404,10407,10410,10413)
                 // warnings are NOT suppressed because those contracts ARE deployed
                 // on-chain.
-                ignore |= (self.is_test(path) || self.is_script(path))
-                    && SHIELDED_WARNINGS_SUPPRESSIBLE_IN_TESTS.contains(&code);
+                //
+                // Scripts always suppress. Tests suppress unless
+                // seismic_warnings_in_tests is set.
+                if SHIELDED_WARNINGS_SUPPRESSIBLE_IN_TESTS.contains(&code) {
+                    ignore |= self.is_script(path);
+                    if !seismic_warnings_in_tests {
+                        ignore |= self.is_test(path);
+                    }
+                }
             }
         }
 
@@ -991,6 +1044,10 @@ pub struct OutputDiagnostics<'a, C: Compiler> {
     ignored_file_paths: &'a [PathBuf],
     /// set minimum level of severity that is treated as an error
     compiler_severity_filter: Severity,
+    /// When true, show seismic warnings (code >= 10000) even in test files.
+    seismic_warnings_in_tests: bool,
+    /// When true, suppress ALL seismic warnings (code >= 10000) globally.
+    no_seismic_warnings: bool,
 }
 
 impl<C: Compiler> OutputDiagnostics<'_, C> {
@@ -1000,12 +1057,19 @@ impl<C: Compiler> OutputDiagnostics<'_, C> {
             self.ignored_error_codes,
             self.ignored_file_paths,
             &self.compiler_severity_filter,
+            self.seismic_warnings_in_tests,
+            self.no_seismic_warnings,
         )
     }
 
     /// Returns true if there is at least one warning
     pub fn has_warning(&self) -> bool {
-        self.compiler_output.has_warning(self.ignored_error_codes, self.ignored_file_paths)
+        self.compiler_output.has_warning(
+            self.ignored_error_codes,
+            self.ignored_file_paths,
+            self.seismic_warnings_in_tests,
+            self.no_seismic_warnings,
+        )
     }
 }
 
@@ -1025,6 +1089,8 @@ impl<C: Compiler> fmt::Display for OutputDiagnostics<'_, C> {
                 self.ignored_error_codes,
                 self.ignored_file_paths,
                 err,
+                self.seismic_warnings_in_tests,
+                self.no_seismic_warnings,
             ) {
                 f.write_str("\n")?;
                 fmt::Display::fmt(&err, f)?;
@@ -1093,7 +1159,19 @@ mod tests {
     fn is_suppressed(code: u64, file: &str) -> bool {
         let output = make_output();
         let warning = make_warning(code, file);
-        output.should_ignore(&[], &[], &warning)
+        output.should_ignore(&[], &[], &warning, false, false)
+    }
+
+    /// Helper: returns true if the warning would be suppressed with given seismic flags.
+    fn is_suppressed_with_flags(
+        code: u64,
+        file: &str,
+        seismic_warnings_in_tests: bool,
+        no_seismic_warnings: bool,
+    ) -> bool {
+        let output = make_output();
+        let warning = make_warning(code, file);
+        output.should_ignore(&[], &[], &warning, seismic_warnings_in_tests, no_seismic_warnings)
     }
 
     // src/ files: nothing suppressed
@@ -1217,7 +1295,7 @@ mod tests {
     fn errors_are_never_suppressed() {
         let output = make_output();
         let error = make_error(SHIELDED_LITERAL_OTHER_INT, "test/Foo.t.sol");
-        assert!(!output.should_ignore(&[], &[], &error));
+        assert!(!output.should_ignore(&[], &[], &error, false, false));
     }
 
     // constant values are correct
@@ -1256,5 +1334,156 @@ mod tests {
         assert!(!SHIELDED_WARNINGS_SUPPRESSIBLE_IN_TESTS
             .contains(&SHIELDED_LITERAL_NEW_EXPR_FIXEDBYTES));
         assert!(!SHIELDED_WARNINGS_SUPPRESSIBLE_IN_TESTS.contains(&SHIELDED_LITERAL_NEW_EXPR_ENUM));
+    }
+
+    // --no-seismic-warnings suppresses ALL seismic warnings globally
+
+    #[test]
+    fn no_seismic_warnings_suppresses_all_in_src() {
+        assert!(is_suppressed_with_flags(SHIELDED_CONSTRUCTOR_PARAM, "src/Foo.sol", false, true));
+        assert!(is_suppressed_with_flags(
+            SHIELDED_LITERAL_NEW_EXPR_INT,
+            "src/Foo.sol",
+            false,
+            true
+        ));
+        assert!(is_suppressed_with_flags(
+            SHIELDED_LITERAL_EXT_CALL_INT,
+            "src/Foo.sol",
+            false,
+            true
+        ));
+        assert!(is_suppressed_with_flags(SHIELDED_LITERAL_OTHER_INT, "src/Foo.sol", false, true));
+    }
+
+    #[test]
+    fn no_seismic_warnings_suppresses_all_in_test() {
+        assert!(is_suppressed_with_flags(
+            SHIELDED_CONSTRUCTOR_PARAM,
+            "test/Foo.t.sol",
+            false,
+            true
+        ));
+        assert!(is_suppressed_with_flags(
+            SHIELDED_LITERAL_NEW_EXPR_INT,
+            "test/Foo.t.sol",
+            false,
+            true
+        ));
+        assert!(is_suppressed_with_flags(
+            SHIELDED_LITERAL_EXT_CALL_INT,
+            "test/Foo.t.sol",
+            false,
+            true
+        ));
+        assert!(is_suppressed_with_flags(
+            SHIELDED_LITERAL_OTHER_INT,
+            "test/Foo.t.sol",
+            false,
+            true
+        ));
+    }
+
+    #[test]
+    fn no_seismic_warnings_does_not_suppress_non_seismic() {
+        // Warning code below threshold should not be affected
+        assert!(!is_suppressed_with_flags(1878, "src/Foo.sol", false, true));
+        assert!(!is_suppressed_with_flags(5574, "src/Foo.sol", false, true));
+    }
+
+    #[test]
+    fn no_seismic_warnings_errors_never_suppressed() {
+        let output = make_output();
+        let error = make_error(SHIELDED_LITERAL_OTHER_INT, "src/Foo.sol");
+        assert!(!output.should_ignore(&[], &[], &error, false, true));
+    }
+
+    // --seismic-warnings-in-tests disables test suppression (not script)
+
+    #[test]
+    fn seismic_warnings_in_tests_shows_ext_call_in_test() {
+        // Normally suppressed in test files
+        assert!(is_suppressed_with_flags(
+            SHIELDED_LITERAL_EXT_CALL_INT,
+            "test/Foo.t.sol",
+            false,
+            false
+        ));
+        // With flag, no longer suppressed
+        assert!(!is_suppressed_with_flags(
+            SHIELDED_LITERAL_EXT_CALL_INT,
+            "test/Foo.t.sol",
+            true,
+            false
+        ));
+    }
+
+    #[test]
+    fn seismic_warnings_in_tests_shows_other_in_test() {
+        assert!(is_suppressed_with_flags(
+            SHIELDED_LITERAL_OTHER_INT,
+            "test/Foo.t.sol",
+            false,
+            false
+        ));
+        assert!(!is_suppressed_with_flags(
+            SHIELDED_LITERAL_OTHER_INT,
+            "test/Foo.t.sol",
+            true,
+            false
+        ));
+    }
+
+    #[test]
+    fn seismic_warnings_in_tests_no_effect_on_script() {
+        // Scripts always suppress — flag only affects test files
+        assert!(is_suppressed_with_flags(
+            SHIELDED_LITERAL_EXT_CALL_INT,
+            "script/Deploy.s.sol",
+            false,
+            false
+        ));
+        assert!(is_suppressed_with_flags(
+            SHIELDED_LITERAL_EXT_CALL_INT,
+            "script/Deploy.s.sol",
+            true,
+            false
+        ));
+    }
+
+    #[test]
+    fn seismic_warnings_in_tests_no_effect_on_src() {
+        // src/ files already show all warnings; flag should not change behavior
+        assert!(!is_suppressed_with_flags(
+            SHIELDED_LITERAL_EXT_CALL_INT,
+            "src/Foo.sol",
+            false,
+            false
+        ));
+        assert!(!is_suppressed_with_flags(
+            SHIELDED_LITERAL_EXT_CALL_INT,
+            "src/Foo.sol",
+            true,
+            false
+        ));
+    }
+
+    // no_seismic_warnings takes precedence over seismic_warnings_in_tests
+
+    #[test]
+    fn no_seismic_warnings_takes_precedence() {
+        // Both flags set: no_seismic_warnings should still suppress
+        assert!(is_suppressed_with_flags(
+            SHIELDED_LITERAL_EXT_CALL_INT,
+            "test/Foo.t.sol",
+            true,
+            true
+        ));
+        assert!(is_suppressed_with_flags(SHIELDED_LITERAL_OTHER_INT, "src/Foo.sol", true, true));
+    }
+
+    #[test]
+    fn seismic_warning_threshold_is_correct() {
+        assert_eq!(SEISMIC_WARNING_THRESHOLD, 10000);
     }
 }

--- a/crates/compilers/src/compile/output/mod.rs
+++ b/crates/compilers/src/compile/output/mod.rs
@@ -54,8 +54,10 @@ pub struct SeismicConfig {
     pub no_seismic_warnings: bool,
 }
 
-/// Warnings suppressed in test/script files — bytecode never deployed, calldata encrypted.
-const SHIELDED_WARNINGS_SUPPRESSIBLE_IN_TESTS: &[u64] = &[
+/// Shielded warnings safe to suppress in script files — script bytecode is never deployed
+/// on-chain, and external call calldata is encrypted by the broadcast mechanism.
+/// Constructor/new-expression warnings are excluded because scripts DO deploy contracts.
+const SHIELDED_WARNINGS_SUPPRESSIBLE_IN_SCRIPTS: &[u64] = &[
     // External call context
     SHIELDED_LITERAL_EXT_CALL_INT,
     SHIELDED_LITERAL_EXT_CALL_BOOL,
@@ -972,18 +974,20 @@ impl<C: Compiler> AggregatedCompilerOutput<C> {
                 // from a test file we skip
                 ignore |= self.is_test(path) && (code == 1878 || code == 5574);
 
-                // Suppress shielded literal warnings that are safe in test/script files.
-                // Constructor param (10103) and new-expression (10401,10404,10407,10410,10413)
-                // warnings are NOT suppressed because those contracts ARE deployed
-                // on-chain.
-                //
-                // Scripts always suppress. Tests suppress unless
-                // seismic_warnings_in_tests is set.
-                if SHIELDED_WARNINGS_SUPPRESSIBLE_IN_TESTS.contains(&code) {
+                // Tests: suppress ALL seismic warnings by default (tests never deploy
+                // to mainnet). The seismic_warnings_in_tests flag opts out of this.
+                if code >= SEISMIC_WARNING_THRESHOLD
+                    && self.is_test(path)
+                    && !seismic_cfg.seismic_warnings_in_tests
+                {
+                    return true;
+                }
+
+                // Scripts: suppress only the safe subset (ext-call + other context).
+                // Constructor/new-expression warnings are NOT suppressed because
+                // scripts DO deploy contracts on-chain.
+                if SHIELDED_WARNINGS_SUPPRESSIBLE_IN_SCRIPTS.contains(&code) {
                     ignore |= self.is_script(path);
-                    if !seismic_cfg.seismic_warnings_in_tests {
-                        ignore |= self.is_test(path);
-                    }
                 }
             }
         }
@@ -1174,38 +1178,37 @@ mod tests {
         assert!(!is_suppressed(SHIELDED_LITERAL_OTHER_ENUM, "src/Foo.sol"));
     }
 
-    // test/ files
+    // test/ files — ALL seismic warnings suppressed by default
 
     #[test]
-    fn test_file_shows_constructor_param_warning() {
-        assert!(!is_suppressed(SHIELDED_CONSTRUCTOR_PARAM, "test/Foo.t.sol"));
+    fn test_file_suppresses_all_seismic_warnings() {
+        let f = "test/Foo.t.sol";
+        // Constructor param
+        assert!(is_suppressed(SHIELDED_CONSTRUCTOR_PARAM, f));
+        // New-expression
+        assert!(is_suppressed(SHIELDED_LITERAL_NEW_EXPR_INT, f));
+        assert!(is_suppressed(SHIELDED_LITERAL_NEW_EXPR_BOOL, f));
+        assert!(is_suppressed(SHIELDED_LITERAL_NEW_EXPR_ADDRESS, f));
+        assert!(is_suppressed(SHIELDED_LITERAL_NEW_EXPR_FIXEDBYTES, f));
+        assert!(is_suppressed(SHIELDED_LITERAL_NEW_EXPR_ENUM, f));
+        // External call
+        assert!(is_suppressed(SHIELDED_LITERAL_EXT_CALL_INT, f));
+        assert!(is_suppressed(SHIELDED_LITERAL_EXT_CALL_BOOL, f));
+        assert!(is_suppressed(SHIELDED_LITERAL_EXT_CALL_ADDRESS, f));
+        assert!(is_suppressed(SHIELDED_LITERAL_EXT_CALL_FIXEDBYTES, f));
+        assert!(is_suppressed(SHIELDED_LITERAL_EXT_CALL_ENUM, f));
+        // Other context
+        assert!(is_suppressed(SHIELDED_LITERAL_OTHER_INT, f));
+        assert!(is_suppressed(SHIELDED_LITERAL_OTHER_BOOL, f));
+        assert!(is_suppressed(SHIELDED_LITERAL_OTHER_ADDRESS, f));
+        assert!(is_suppressed(SHIELDED_LITERAL_OTHER_FIXEDBYTES, f));
+        assert!(is_suppressed(SHIELDED_LITERAL_OTHER_ENUM, f));
     }
 
     #[test]
-    fn test_file_shows_new_expr_warnings() {
-        assert!(!is_suppressed(SHIELDED_LITERAL_NEW_EXPR_INT, "test/Foo.t.sol"));
-        assert!(!is_suppressed(SHIELDED_LITERAL_NEW_EXPR_BOOL, "test/Foo.t.sol"));
-        assert!(!is_suppressed(SHIELDED_LITERAL_NEW_EXPR_ADDRESS, "test/Foo.t.sol"));
-        assert!(!is_suppressed(SHIELDED_LITERAL_NEW_EXPR_FIXEDBYTES, "test/Foo.t.sol"));
-        assert!(!is_suppressed(SHIELDED_LITERAL_NEW_EXPR_ENUM, "test/Foo.t.sol"));
-    }
-
-    #[test]
-    fn test_file_suppresses_ext_call_warnings() {
-        assert!(is_suppressed(SHIELDED_LITERAL_EXT_CALL_INT, "test/Foo.t.sol"));
-        assert!(is_suppressed(SHIELDED_LITERAL_EXT_CALL_BOOL, "test/Foo.t.sol"));
-        assert!(is_suppressed(SHIELDED_LITERAL_EXT_CALL_ADDRESS, "test/Foo.t.sol"));
-        assert!(is_suppressed(SHIELDED_LITERAL_EXT_CALL_FIXEDBYTES, "test/Foo.t.sol"));
-        assert!(is_suppressed(SHIELDED_LITERAL_EXT_CALL_ENUM, "test/Foo.t.sol"));
-    }
-
-    #[test]
-    fn test_file_suppresses_other_context_warnings() {
-        assert!(is_suppressed(SHIELDED_LITERAL_OTHER_INT, "test/Foo.t.sol"));
-        assert!(is_suppressed(SHIELDED_LITERAL_OTHER_BOOL, "test/Foo.t.sol"));
-        assert!(is_suppressed(SHIELDED_LITERAL_OTHER_ADDRESS, "test/Foo.t.sol"));
-        assert!(is_suppressed(SHIELDED_LITERAL_OTHER_FIXEDBYTES, "test/Foo.t.sol"));
-        assert!(is_suppressed(SHIELDED_LITERAL_OTHER_ENUM, "test/Foo.t.sol"));
+    fn test_file_does_not_suppress_non_seismic_warnings() {
+        // Non-seismic warnings (e.g. SPDX, code-size) are handled separately
+        assert!(!is_suppressed(2018, "test/Foo.t.sol")); // func-mutability
     }
 
     // script/ files
@@ -1296,16 +1299,20 @@ mod tests {
 
     #[test]
     fn suppressible_collection_has_correct_entries() {
-        assert_eq!(SHIELDED_WARNINGS_SUPPRESSIBLE_IN_TESTS.len(), 10);
-        assert!(!SHIELDED_WARNINGS_SUPPRESSIBLE_IN_TESTS.contains(&SHIELDED_CONSTRUCTOR_PARAM));
-        assert!(!SHIELDED_WARNINGS_SUPPRESSIBLE_IN_TESTS.contains(&SHIELDED_LITERAL_NEW_EXPR_INT));
-        assert!(!SHIELDED_WARNINGS_SUPPRESSIBLE_IN_TESTS.contains(&SHIELDED_LITERAL_NEW_EXPR_BOOL));
+        assert_eq!(SHIELDED_WARNINGS_SUPPRESSIBLE_IN_SCRIPTS.len(), 10);
+        assert!(!SHIELDED_WARNINGS_SUPPRESSIBLE_IN_SCRIPTS.contains(&SHIELDED_CONSTRUCTOR_PARAM));
+        assert!(!SHIELDED_WARNINGS_SUPPRESSIBLE_IN_SCRIPTS.contains(&SHIELDED_LITERAL_NEW_EXPR_INT));
         assert!(
-            !SHIELDED_WARNINGS_SUPPRESSIBLE_IN_TESTS.contains(&SHIELDED_LITERAL_NEW_EXPR_ADDRESS)
+            !SHIELDED_WARNINGS_SUPPRESSIBLE_IN_SCRIPTS.contains(&SHIELDED_LITERAL_NEW_EXPR_BOOL)
         );
-        assert!(!SHIELDED_WARNINGS_SUPPRESSIBLE_IN_TESTS
+        assert!(
+            !SHIELDED_WARNINGS_SUPPRESSIBLE_IN_SCRIPTS.contains(&SHIELDED_LITERAL_NEW_EXPR_ADDRESS)
+        );
+        assert!(!SHIELDED_WARNINGS_SUPPRESSIBLE_IN_SCRIPTS
             .contains(&SHIELDED_LITERAL_NEW_EXPR_FIXEDBYTES));
-        assert!(!SHIELDED_WARNINGS_SUPPRESSIBLE_IN_TESTS.contains(&SHIELDED_LITERAL_NEW_EXPR_ENUM));
+        assert!(
+            !SHIELDED_WARNINGS_SUPPRESSIBLE_IN_SCRIPTS.contains(&SHIELDED_LITERAL_NEW_EXPR_ENUM)
+        );
     }
 
     // --no-seismic-warnings suppresses ALL seismic warnings globally
@@ -1347,19 +1354,15 @@ mod tests {
         assert!(!output.should_ignore(&[], &[], &error, NO_WARNINGS));
     }
 
-    // --seismic-warnings-in-tests disables test suppression (not script)
+    // --seismic-warnings-in-tests disables blanket test suppression (not script)
 
     #[test]
-    fn seismic_warnings_in_tests_shows_ext_call_in_test() {
+    fn seismic_warnings_in_tests_shows_all_in_test() {
         let f = "test/Foo.t.sol";
-        assert!(is_suppressed(SHIELDED_LITERAL_EXT_CALL_INT, f));
+        // With SHOW_IN_TESTS, nothing is blanket-suppressed
+        assert!(!is_suppressed_with_cfg(SHIELDED_CONSTRUCTOR_PARAM, f, SHOW_IN_TESTS));
+        assert!(!is_suppressed_with_cfg(SHIELDED_LITERAL_NEW_EXPR_INT, f, SHOW_IN_TESTS));
         assert!(!is_suppressed_with_cfg(SHIELDED_LITERAL_EXT_CALL_INT, f, SHOW_IN_TESTS));
-    }
-
-    #[test]
-    fn seismic_warnings_in_tests_shows_other_in_test() {
-        let f = "test/Foo.t.sol";
-        assert!(is_suppressed(SHIELDED_LITERAL_OTHER_INT, f));
         assert!(!is_suppressed_with_cfg(SHIELDED_LITERAL_OTHER_INT, f, SHOW_IN_TESTS));
     }
 

--- a/crates/compilers/src/compile/output/mod.rs
+++ b/crates/compilers/src/compile/output/mod.rs
@@ -45,6 +45,15 @@ const SHIELDED_LITERAL_OTHER_ENUM: u64 = 10415;
 /// Threshold above which a warning code is considered a seismic warning.
 const SEISMIC_WARNING_THRESHOLD: u64 = 10000;
 
+/// Configuration for seismic warning suppression.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct SeismicConfig {
+    /// When true, show seismic warnings (code >= 10000) even in test files.
+    pub seismic_warnings_in_tests: bool,
+    /// When true, suppress ALL seismic warnings (code >= 10000) globally.
+    pub no_seismic_warnings: bool,
+}
+
 /// Warnings suppressed in test/script files — bytecode never deployed, calldata encrypted.
 const SHIELDED_WARNINGS_SUPPRESSIBLE_IN_TESTS: &[u64] = &[
     // External call context
@@ -142,10 +151,8 @@ pub struct ProjectCompileOutput<
     pub(crate) ignored_file_paths: Vec<PathBuf>,
     /// set minimum level of severity that is treated as an error
     pub(crate) compiler_severity_filter: Severity,
-    /// When true, show seismic warnings (code >= 10000) even in test files.
-    pub(crate) seismic_warnings_in_tests: bool,
-    /// When true, suppress ALL seismic warnings (code >= 10000) globally.
-    pub(crate) no_seismic_warnings: bool,
+    /// Seismic warning suppression config.
+    pub(crate) seismic_cfg: SeismicConfig,
     /// all build infos that were just compiled
     pub(crate) builds: Builds<C::Language>,
     /// The relationship between the source files and their imports
@@ -555,8 +562,7 @@ impl<C: Compiler, T: ArtifactOutput<CompilerContract = C::CompilerContract>>
             &self.ignored_error_codes,
             &self.ignored_file_paths,
             &self.compiler_severity_filter,
-            self.seismic_warnings_in_tests,
-            self.no_seismic_warnings,
+            self.seismic_cfg,
         )
     }
 
@@ -565,8 +571,7 @@ impl<C: Compiler, T: ArtifactOutput<CompilerContract = C::CompilerContract>>
         self.compiler_output.has_warning(
             &self.ignored_error_codes,
             &self.ignored_file_paths,
-            self.seismic_warnings_in_tests,
-            self.no_seismic_warnings,
+            self.seismic_cfg,
         )
     }
 
@@ -596,8 +601,7 @@ impl<C: Compiler, T: ArtifactOutput<CompilerContract = C::CompilerContract>> fmt
                     &self.ignored_error_codes,
                     &self.ignored_file_paths,
                     self.compiler_severity_filter,
-                    self.seismic_warnings_in_tests,
-                    self.no_seismic_warnings,
+                    self.seismic_cfg,
                 )
                 .fmt(f)
         }
@@ -642,16 +646,14 @@ impl<C: Compiler> AggregatedCompilerOutput<C> {
         ignored_error_codes: &'a [u64],
         ignored_file_paths: &'a [PathBuf],
         compiler_severity_filter: Severity,
-        seismic_warnings_in_tests: bool,
-        no_seismic_warnings: bool,
+        seismic_cfg: SeismicConfig,
     ) -> OutputDiagnostics<'a, C> {
         OutputDiagnostics {
             compiler_output: self,
             ignored_error_codes,
             ignored_file_paths,
             compiler_severity_filter,
-            seismic_warnings_in_tests,
-            no_seismic_warnings,
+            seismic_cfg,
         }
     }
 
@@ -912,24 +914,15 @@ impl<C: Compiler> AggregatedCompilerOutput<C> {
         ignored_error_codes: &[u64],
         ignored_file_paths: &[PathBuf],
         compiler_severity_filter: &Severity,
-        seismic_warnings_in_tests: bool,
-        no_seismic_warnings: bool,
+        seismic_cfg: SeismicConfig,
     ) -> bool {
         self.errors.iter().any(|err| {
             if err.is_error() {
-                // [Severity::Error] is always treated as an error
                 return true;
             }
-            // check if the filter is set to something higher than the error's severity
             if compiler_severity_filter.ge(&err.severity()) {
                 if compiler_severity_filter.is_warning() {
-                    // skip ignored error codes and file path from warnings
-                    return self.has_warning(
-                        ignored_error_codes,
-                        ignored_file_paths,
-                        seismic_warnings_in_tests,
-                        no_seismic_warnings,
-                    );
+                    return self.has_warning(ignored_error_codes, ignored_file_paths, seismic_cfg);
                 }
                 return true;
             }
@@ -943,17 +936,10 @@ impl<C: Compiler> AggregatedCompilerOutput<C> {
         &self,
         ignored_error_codes: &[u64],
         ignored_file_paths: &[PathBuf],
-        seismic_warnings_in_tests: bool,
-        no_seismic_warnings: bool,
+        seismic_cfg: SeismicConfig,
     ) -> bool {
         self.errors.iter().any(|error| {
-            !self.should_ignore(
-                ignored_error_codes,
-                ignored_file_paths,
-                error,
-                seismic_warnings_in_tests,
-                no_seismic_warnings,
-            )
+            !self.should_ignore(ignored_error_codes, ignored_file_paths, error, seismic_cfg)
         })
     }
 
@@ -962,8 +948,7 @@ impl<C: Compiler> AggregatedCompilerOutput<C> {
         ignored_error_codes: &[u64],
         ignored_file_paths: &[PathBuf],
         error: &C::CompilationError,
-        seismic_warnings_in_tests: bool,
-        no_seismic_warnings: bool,
+        seismic_cfg: SeismicConfig,
     ) -> bool {
         if !error.is_warning() {
             return false;
@@ -972,8 +957,7 @@ impl<C: Compiler> AggregatedCompilerOutput<C> {
         let mut ignore = false;
 
         if let Some(code) = error.error_code() {
-            // If no_seismic_warnings is set, suppress ALL seismic warnings globally.
-            if no_seismic_warnings && code >= SEISMIC_WARNING_THRESHOLD {
+            if seismic_cfg.no_seismic_warnings && code >= SEISMIC_WARNING_THRESHOLD {
                 return true;
             }
 
@@ -997,7 +981,7 @@ impl<C: Compiler> AggregatedCompilerOutput<C> {
                 // seismic_warnings_in_tests is set.
                 if SHIELDED_WARNINGS_SUPPRESSIBLE_IN_TESTS.contains(&code) {
                     ignore |= self.is_script(path);
-                    if !seismic_warnings_in_tests {
+                    if !seismic_cfg.seismic_warnings_in_tests {
                         ignore |= self.is_test(path);
                     }
                 }
@@ -1044,10 +1028,8 @@ pub struct OutputDiagnostics<'a, C: Compiler> {
     ignored_file_paths: &'a [PathBuf],
     /// set minimum level of severity that is treated as an error
     compiler_severity_filter: Severity,
-    /// When true, show seismic warnings (code >= 10000) even in test files.
-    seismic_warnings_in_tests: bool,
-    /// When true, suppress ALL seismic warnings (code >= 10000) globally.
-    no_seismic_warnings: bool,
+    /// Seismic warning suppression config.
+    seismic_cfg: SeismicConfig,
 }
 
 impl<C: Compiler> OutputDiagnostics<'_, C> {
@@ -1057,8 +1039,7 @@ impl<C: Compiler> OutputDiagnostics<'_, C> {
             self.ignored_error_codes,
             self.ignored_file_paths,
             &self.compiler_severity_filter,
-            self.seismic_warnings_in_tests,
-            self.no_seismic_warnings,
+            self.seismic_cfg,
         )
     }
 
@@ -1067,8 +1048,7 @@ impl<C: Compiler> OutputDiagnostics<'_, C> {
         self.compiler_output.has_warning(
             self.ignored_error_codes,
             self.ignored_file_paths,
-            self.seismic_warnings_in_tests,
-            self.no_seismic_warnings,
+            self.seismic_cfg,
         )
     }
 }
@@ -1089,8 +1069,7 @@ impl<C: Compiler> fmt::Display for OutputDiagnostics<'_, C> {
                 self.ignored_error_codes,
                 self.ignored_file_paths,
                 err,
-                self.seismic_warnings_in_tests,
-                self.no_seismic_warnings,
+                self.seismic_cfg,
             ) {
                 f.write_str("\n")?;
                 fmt::Display::fmt(&err, f)?;
@@ -1159,19 +1138,14 @@ mod tests {
     fn is_suppressed(code: u64, file: &str) -> bool {
         let output = make_output();
         let warning = make_warning(code, file);
-        output.should_ignore(&[], &[], &warning, false, false)
+        output.should_ignore(&[], &[], &warning, SeismicConfig::default())
     }
 
-    /// Helper: returns true if the warning would be suppressed with given seismic flags.
-    fn is_suppressed_with_flags(
-        code: u64,
-        file: &str,
-        seismic_warnings_in_tests: bool,
-        no_seismic_warnings: bool,
-    ) -> bool {
+    /// Helper: returns true if the warning would be suppressed with given seismic config.
+    fn is_suppressed_with_cfg(code: u64, file: &str, cfg: SeismicConfig) -> bool {
         let output = make_output();
         let warning = make_warning(code, file);
-        output.should_ignore(&[], &[], &warning, seismic_warnings_in_tests, no_seismic_warnings)
+        output.should_ignore(&[], &[], &warning, cfg)
     }
 
     // src/ files: nothing suppressed
@@ -1295,7 +1269,7 @@ mod tests {
     fn errors_are_never_suppressed() {
         let output = make_output();
         let error = make_error(SHIELDED_LITERAL_OTHER_INT, "test/Foo.t.sol");
-        assert!(!output.should_ignore(&[], &[], &error, false, false));
+        assert!(!output.should_ignore(&[], &[], &error, SeismicConfig::default()));
     }
 
     // constant values are correct
@@ -1322,9 +1296,7 @@ mod tests {
 
     #[test]
     fn suppressible_collection_has_correct_entries() {
-        // Should contain ext call + other context = 10 entries
         assert_eq!(SHIELDED_WARNINGS_SUPPRESSIBLE_IN_TESTS.len(), 10);
-        // Should NOT contain constructor param or new-expression warnings
         assert!(!SHIELDED_WARNINGS_SUPPRESSIBLE_IN_TESTS.contains(&SHIELDED_CONSTRUCTOR_PARAM));
         assert!(!SHIELDED_WARNINGS_SUPPRESSIBLE_IN_TESTS.contains(&SHIELDED_LITERAL_NEW_EXPR_INT));
         assert!(!SHIELDED_WARNINGS_SUPPRESSIBLE_IN_TESTS.contains(&SHIELDED_LITERAL_NEW_EXPR_BOOL));
@@ -1338,133 +1310,73 @@ mod tests {
 
     // --no-seismic-warnings suppresses ALL seismic warnings globally
 
+    const NO_WARNINGS: SeismicConfig =
+        SeismicConfig { no_seismic_warnings: true, seismic_warnings_in_tests: false };
+    const SHOW_IN_TESTS: SeismicConfig =
+        SeismicConfig { seismic_warnings_in_tests: true, no_seismic_warnings: false };
+    const BOTH: SeismicConfig =
+        SeismicConfig { seismic_warnings_in_tests: true, no_seismic_warnings: true };
+
     #[test]
     fn no_seismic_warnings_suppresses_all_in_src() {
-        assert!(is_suppressed_with_flags(SHIELDED_CONSTRUCTOR_PARAM, "src/Foo.sol", false, true));
-        assert!(is_suppressed_with_flags(
-            SHIELDED_LITERAL_NEW_EXPR_INT,
-            "src/Foo.sol",
-            false,
-            true
-        ));
-        assert!(is_suppressed_with_flags(
-            SHIELDED_LITERAL_EXT_CALL_INT,
-            "src/Foo.sol",
-            false,
-            true
-        ));
-        assert!(is_suppressed_with_flags(SHIELDED_LITERAL_OTHER_INT, "src/Foo.sol", false, true));
+        assert!(is_suppressed_with_cfg(SHIELDED_CONSTRUCTOR_PARAM, "src/Foo.sol", NO_WARNINGS));
+        assert!(is_suppressed_with_cfg(SHIELDED_LITERAL_NEW_EXPR_INT, "src/Foo.sol", NO_WARNINGS));
+        assert!(is_suppressed_with_cfg(SHIELDED_LITERAL_EXT_CALL_INT, "src/Foo.sol", NO_WARNINGS));
+        assert!(is_suppressed_with_cfg(SHIELDED_LITERAL_OTHER_INT, "src/Foo.sol", NO_WARNINGS));
     }
 
     #[test]
     fn no_seismic_warnings_suppresses_all_in_test() {
-        assert!(is_suppressed_with_flags(
-            SHIELDED_CONSTRUCTOR_PARAM,
-            "test/Foo.t.sol",
-            false,
-            true
-        ));
-        assert!(is_suppressed_with_flags(
-            SHIELDED_LITERAL_NEW_EXPR_INT,
-            "test/Foo.t.sol",
-            false,
-            true
-        ));
-        assert!(is_suppressed_with_flags(
-            SHIELDED_LITERAL_EXT_CALL_INT,
-            "test/Foo.t.sol",
-            false,
-            true
-        ));
-        assert!(is_suppressed_with_flags(
-            SHIELDED_LITERAL_OTHER_INT,
-            "test/Foo.t.sol",
-            false,
-            true
-        ));
+        let f = "test/Foo.t.sol";
+        assert!(is_suppressed_with_cfg(SHIELDED_CONSTRUCTOR_PARAM, f, NO_WARNINGS));
+        assert!(is_suppressed_with_cfg(SHIELDED_LITERAL_NEW_EXPR_INT, f, NO_WARNINGS));
+        assert!(is_suppressed_with_cfg(SHIELDED_LITERAL_EXT_CALL_INT, f, NO_WARNINGS));
+        assert!(is_suppressed_with_cfg(SHIELDED_LITERAL_OTHER_INT, f, NO_WARNINGS));
     }
 
     #[test]
     fn no_seismic_warnings_does_not_suppress_non_seismic() {
-        // Warning code below threshold should not be affected
-        assert!(!is_suppressed_with_flags(1878, "src/Foo.sol", false, true));
-        assert!(!is_suppressed_with_flags(5574, "src/Foo.sol", false, true));
+        assert!(!is_suppressed_with_cfg(1878, "src/Foo.sol", NO_WARNINGS));
+        assert!(!is_suppressed_with_cfg(5574, "src/Foo.sol", NO_WARNINGS));
     }
 
     #[test]
     fn no_seismic_warnings_errors_never_suppressed() {
         let output = make_output();
         let error = make_error(SHIELDED_LITERAL_OTHER_INT, "src/Foo.sol");
-        assert!(!output.should_ignore(&[], &[], &error, false, true));
+        assert!(!output.should_ignore(&[], &[], &error, NO_WARNINGS));
     }
 
     // --seismic-warnings-in-tests disables test suppression (not script)
 
     #[test]
     fn seismic_warnings_in_tests_shows_ext_call_in_test() {
-        // Normally suppressed in test files
-        assert!(is_suppressed_with_flags(
-            SHIELDED_LITERAL_EXT_CALL_INT,
-            "test/Foo.t.sol",
-            false,
-            false
-        ));
-        // With flag, no longer suppressed
-        assert!(!is_suppressed_with_flags(
-            SHIELDED_LITERAL_EXT_CALL_INT,
-            "test/Foo.t.sol",
-            true,
-            false
-        ));
+        let f = "test/Foo.t.sol";
+        assert!(is_suppressed(SHIELDED_LITERAL_EXT_CALL_INT, f));
+        assert!(!is_suppressed_with_cfg(SHIELDED_LITERAL_EXT_CALL_INT, f, SHOW_IN_TESTS));
     }
 
     #[test]
     fn seismic_warnings_in_tests_shows_other_in_test() {
-        assert!(is_suppressed_with_flags(
-            SHIELDED_LITERAL_OTHER_INT,
-            "test/Foo.t.sol",
-            false,
-            false
-        ));
-        assert!(!is_suppressed_with_flags(
-            SHIELDED_LITERAL_OTHER_INT,
-            "test/Foo.t.sol",
-            true,
-            false
-        ));
+        let f = "test/Foo.t.sol";
+        assert!(is_suppressed(SHIELDED_LITERAL_OTHER_INT, f));
+        assert!(!is_suppressed_with_cfg(SHIELDED_LITERAL_OTHER_INT, f, SHOW_IN_TESTS));
     }
 
     #[test]
     fn seismic_warnings_in_tests_no_effect_on_script() {
-        // Scripts always suppress — flag only affects test files
-        assert!(is_suppressed_with_flags(
-            SHIELDED_LITERAL_EXT_CALL_INT,
-            "script/Deploy.s.sol",
-            false,
-            false
-        ));
-        assert!(is_suppressed_with_flags(
-            SHIELDED_LITERAL_EXT_CALL_INT,
-            "script/Deploy.s.sol",
-            true,
-            false
-        ));
+        let f = "script/Deploy.s.sol";
+        assert!(is_suppressed(SHIELDED_LITERAL_EXT_CALL_INT, f));
+        assert!(is_suppressed_with_cfg(SHIELDED_LITERAL_EXT_CALL_INT, f, SHOW_IN_TESTS));
     }
 
     #[test]
     fn seismic_warnings_in_tests_no_effect_on_src() {
-        // src/ files already show all warnings; flag should not change behavior
-        assert!(!is_suppressed_with_flags(
+        assert!(!is_suppressed(SHIELDED_LITERAL_EXT_CALL_INT, "src/Foo.sol"));
+        assert!(!is_suppressed_with_cfg(
             SHIELDED_LITERAL_EXT_CALL_INT,
             "src/Foo.sol",
-            false,
-            false
-        ));
-        assert!(!is_suppressed_with_flags(
-            SHIELDED_LITERAL_EXT_CALL_INT,
-            "src/Foo.sol",
-            true,
-            false
+            SHOW_IN_TESTS
         ));
     }
 
@@ -1472,14 +1384,8 @@ mod tests {
 
     #[test]
     fn no_seismic_warnings_takes_precedence() {
-        // Both flags set: no_seismic_warnings should still suppress
-        assert!(is_suppressed_with_flags(
-            SHIELDED_LITERAL_EXT_CALL_INT,
-            "test/Foo.t.sol",
-            true,
-            true
-        ));
-        assert!(is_suppressed_with_flags(SHIELDED_LITERAL_OTHER_INT, "src/Foo.sol", true, true));
+        assert!(is_suppressed_with_cfg(SHIELDED_LITERAL_EXT_CALL_INT, "test/Foo.t.sol", BOTH));
+        assert!(is_suppressed_with_cfg(SHIELDED_LITERAL_OTHER_INT, "src/Foo.sol", BOTH));
     }
 
     #[test]

--- a/crates/compilers/src/compile/project.rs
+++ b/crates/compilers/src/compile/project.rs
@@ -321,6 +321,8 @@ impl<'a, T: ArtifactOutput<CompilerContract = C::CompilerContract>, C: Compiler>
             &project.ignored_error_codes,
             &project.ignored_file_paths,
             &project.compiler_severity_filter,
+            project.seismic_warnings_in_tests,
+            project.no_seismic_warnings,
         ) {
             trace!("skip writing cache file due to solc errors: {:?}", output.errors);
             project.artifacts_handler().output_to_artifacts(
@@ -376,8 +378,15 @@ impl<T: ArtifactOutput<CompilerContract = C::CompilerContract>, C: Compiler>
         let ignored_error_codes = project.ignored_error_codes.clone();
         let ignored_file_paths = project.ignored_file_paths.clone();
         let compiler_severity_filter = project.compiler_severity_filter;
-        let has_error =
-            output.has_error(&ignored_error_codes, &ignored_file_paths, &compiler_severity_filter);
+        let seismic_warnings_in_tests = project.seismic_warnings_in_tests;
+        let no_seismic_warnings = project.no_seismic_warnings;
+        let has_error = output.has_error(
+            &ignored_error_codes,
+            &ignored_file_paths,
+            &compiler_severity_filter,
+            seismic_warnings_in_tests,
+            no_seismic_warnings,
+        );
         let skip_write_to_disk = project.no_artifacts || has_error;
         trace!(has_error, project.no_artifacts, skip_write_to_disk, cache_path=?project.cache_path(),"prepare writing cache file");
 
@@ -403,6 +412,8 @@ impl<T: ArtifactOutput<CompilerContract = C::CompilerContract>, C: Compiler>
             ignored_error_codes,
             ignored_file_paths,
             compiler_severity_filter,
+            seismic_warnings_in_tests,
+            no_seismic_warnings,
             builds,
             edges,
         })

--- a/crates/compilers/src/compile/project.rs
+++ b/crates/compilers/src/compile/project.rs
@@ -321,8 +321,7 @@ impl<'a, T: ArtifactOutput<CompilerContract = C::CompilerContract>, C: Compiler>
             &project.ignored_error_codes,
             &project.ignored_file_paths,
             &project.compiler_severity_filter,
-            project.seismic_warnings_in_tests,
-            project.no_seismic_warnings,
+            project.seismic_cfg,
         ) {
             trace!("skip writing cache file due to solc errors: {:?}", output.errors);
             project.artifacts_handler().output_to_artifacts(
@@ -378,14 +377,12 @@ impl<T: ArtifactOutput<CompilerContract = C::CompilerContract>, C: Compiler>
         let ignored_error_codes = project.ignored_error_codes.clone();
         let ignored_file_paths = project.ignored_file_paths.clone();
         let compiler_severity_filter = project.compiler_severity_filter;
-        let seismic_warnings_in_tests = project.seismic_warnings_in_tests;
-        let no_seismic_warnings = project.no_seismic_warnings;
+        let seismic_cfg = project.seismic_cfg;
         let has_error = output.has_error(
             &ignored_error_codes,
             &ignored_file_paths,
             &compiler_severity_filter,
-            seismic_warnings_in_tests,
-            no_seismic_warnings,
+            seismic_cfg,
         );
         let skip_write_to_disk = project.no_artifacts || has_error;
         trace!(has_error, project.no_artifacts, skip_write_to_disk, cache_path=?project.cache_path(),"prepare writing cache file");
@@ -412,8 +409,7 @@ impl<T: ArtifactOutput<CompilerContract = C::CompilerContract>, C: Compiler>
             ignored_error_codes,
             ignored_file_paths,
             compiler_severity_filter,
-            seismic_warnings_in_tests,
-            no_seismic_warnings,
+            seismic_cfg,
             builds,
             edges,
         })

--- a/crates/compilers/src/compilers/solc/mod.rs
+++ b/crates/compilers/src/compilers/solc/mod.rs
@@ -178,6 +178,12 @@ pub struct CliSettings {
     pub base_path: Option<PathBuf>,
     #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
     pub include_paths: BTreeSet<PathBuf>,
+    /// When true, show seismic warnings (code >= 10000) even in test files.
+    #[serde(default)]
+    pub seismic_warnings_in_tests: bool,
+    /// When true, suppress ALL seismic warnings (code >= 10000) globally.
+    #[serde(default)]
+    pub no_seismic_warnings: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]

--- a/crates/compilers/src/compilers/solc/mod.rs
+++ b/crates/compilers/src/compilers/solc/mod.rs
@@ -3,6 +3,7 @@ use super::{
     CompilerOutput, CompilerSettings, CompilerVersion, Language, ParsedSource,
 };
 use crate::{
+    compile::output::SeismicConfig,
     resolver::{
         parse::{SolData, SolParser},
         Node,
@@ -178,12 +179,9 @@ pub struct CliSettings {
     pub base_path: Option<PathBuf>,
     #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
     pub include_paths: BTreeSet<PathBuf>,
-    /// When true, show seismic warnings (code >= 10000) even in test files.
+    /// Seismic warning suppression config.
     #[serde(default)]
-    pub seismic_warnings_in_tests: bool,
-    /// When true, suppress ALL seismic warnings (code >= 10000) globally.
-    #[serde(default)]
-    pub no_seismic_warnings: bool,
+    pub seismic_cfg: SeismicConfig,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]

--- a/crates/compilers/src/lib.rs
+++ b/crates/compilers/src/lib.rs
@@ -110,6 +110,10 @@ pub struct Project<
     pub ignored_file_paths: Vec<PathBuf>,
     /// The minimum severity level that is treated as a compiler error
     pub compiler_severity_filter: Severity,
+    /// When true, show seismic warnings (code >= 10000) even in test files.
+    pub seismic_warnings_in_tests: bool,
+    /// When true, suppress ALL seismic warnings (code >= 10000) globally.
+    pub no_seismic_warnings: bool,
     /// Maximum number of `solc` processes to run simultaneously.
     solc_jobs: usize,
     /// Offline mode, if set, network access (download solc) is disallowed
@@ -467,6 +471,10 @@ pub struct ProjectBuilder<
     pub ignored_file_paths: Vec<PathBuf>,
     /// The minimum severity level that is treated as a compiler error
     compiler_severity_filter: Severity,
+    /// When true, show seismic warnings (code >= 10000) even in test files.
+    pub seismic_warnings_in_tests: bool,
+    /// When true, suppress ALL seismic warnings (code >= 10000) globally.
+    pub no_seismic_warnings: bool,
     solc_jobs: Option<usize>,
     /// Optional sparse output filter used to optimize compilation.
     sparse_output: Option<Box<dyn FileFilter>>,
@@ -486,6 +494,8 @@ impl<C: Compiler, T: ArtifactOutput<CompilerContract = C::CompilerContract>> Pro
             ignored_error_codes: Vec::new(),
             ignored_file_paths: Vec::new(),
             compiler_severity_filter: Severity::Error,
+            seismic_warnings_in_tests: false,
+            no_seismic_warnings: false,
             solc_jobs: None,
             settings: None,
             sparse_output: None,
@@ -528,6 +538,20 @@ impl<C: Compiler, T: ArtifactOutput<CompilerContract = C::CompilerContract>> Pro
     #[must_use]
     pub fn set_compiler_severity_filter(mut self, compiler_severity_filter: Severity) -> Self {
         self.compiler_severity_filter = compiler_severity_filter;
+        self
+    }
+
+    /// When true, show seismic warnings (code >= 10000) even in test files.
+    #[must_use]
+    pub fn set_seismic_warnings_in_tests(mut self, seismic_warnings_in_tests: bool) -> Self {
+        self.seismic_warnings_in_tests = seismic_warnings_in_tests;
+        self
+    }
+
+    /// When true, suppress ALL seismic warnings (code >= 10000) globally.
+    #[must_use]
+    pub fn set_no_seismic_warnings(mut self, no_seismic_warnings: bool) -> Self {
+        self.no_seismic_warnings = no_seismic_warnings;
         self
     }
 
@@ -644,6 +668,8 @@ impl<C: Compiler, T: ArtifactOutput<CompilerContract = C::CompilerContract>> Pro
             no_artifacts,
             ignored_error_codes,
             compiler_severity_filter,
+            seismic_warnings_in_tests,
+            no_seismic_warnings,
             solc_jobs,
             offline,
             build_info,
@@ -667,6 +693,8 @@ impl<C: Compiler, T: ArtifactOutput<CompilerContract = C::CompilerContract>> Pro
             ignored_error_codes,
             ignored_file_paths,
             compiler_severity_filter,
+            seismic_warnings_in_tests,
+            no_seismic_warnings,
             solc_jobs,
             build_info,
             settings,
@@ -683,6 +711,8 @@ impl<C: Compiler, T: ArtifactOutput<CompilerContract = C::CompilerContract>> Pro
             ignored_error_codes,
             ignored_file_paths,
             compiler_severity_filter,
+            seismic_warnings_in_tests,
+            no_seismic_warnings,
             solc_jobs,
             offline,
             build_info,
@@ -710,6 +740,8 @@ impl<C: Compiler, T: ArtifactOutput<CompilerContract = C::CompilerContract>> Pro
             ignored_error_codes,
             ignored_file_paths,
             compiler_severity_filter,
+            seismic_warnings_in_tests,
+            no_seismic_warnings,
             solc_jobs: solc_jobs
                 .or_else(|| std::thread::available_parallelism().ok().map(|n| n.get()))
                 .unwrap_or(1),

--- a/crates/compilers/src/lib.rs
+++ b/crates/compilers/src/lib.rs
@@ -26,7 +26,7 @@ pub use compilers::*;
 
 mod compile;
 pub use compile::{
-    output::{AggregatedCompilerOutput, ProjectCompileOutput},
+    output::{AggregatedCompilerOutput, ProjectCompileOutput, SeismicConfig},
     *,
 };
 
@@ -110,10 +110,8 @@ pub struct Project<
     pub ignored_file_paths: Vec<PathBuf>,
     /// The minimum severity level that is treated as a compiler error
     pub compiler_severity_filter: Severity,
-    /// When true, show seismic warnings (code >= 10000) even in test files.
-    pub seismic_warnings_in_tests: bool,
-    /// When true, suppress ALL seismic warnings (code >= 10000) globally.
-    pub no_seismic_warnings: bool,
+    /// Seismic warning suppression config.
+    pub seismic_cfg: SeismicConfig,
     /// Maximum number of `solc` processes to run simultaneously.
     solc_jobs: usize,
     /// Offline mode, if set, network access (download solc) is disallowed
@@ -471,10 +469,8 @@ pub struct ProjectBuilder<
     pub ignored_file_paths: Vec<PathBuf>,
     /// The minimum severity level that is treated as a compiler error
     compiler_severity_filter: Severity,
-    /// When true, show seismic warnings (code >= 10000) even in test files.
-    pub seismic_warnings_in_tests: bool,
-    /// When true, suppress ALL seismic warnings (code >= 10000) globally.
-    pub no_seismic_warnings: bool,
+    /// Seismic warning suppression config.
+    pub seismic_cfg: SeismicConfig,
     solc_jobs: Option<usize>,
     /// Optional sparse output filter used to optimize compilation.
     sparse_output: Option<Box<dyn FileFilter>>,
@@ -494,8 +490,7 @@ impl<C: Compiler, T: ArtifactOutput<CompilerContract = C::CompilerContract>> Pro
             ignored_error_codes: Vec::new(),
             ignored_file_paths: Vec::new(),
             compiler_severity_filter: Severity::Error,
-            seismic_warnings_in_tests: false,
-            no_seismic_warnings: false,
+            seismic_cfg: SeismicConfig::default(),
             solc_jobs: None,
             settings: None,
             sparse_output: None,
@@ -541,17 +536,10 @@ impl<C: Compiler, T: ArtifactOutput<CompilerContract = C::CompilerContract>> Pro
         self
     }
 
-    /// When true, show seismic warnings (code >= 10000) even in test files.
+    /// Set seismic warning suppression config.
     #[must_use]
-    pub fn set_seismic_warnings_in_tests(mut self, seismic_warnings_in_tests: bool) -> Self {
-        self.seismic_warnings_in_tests = seismic_warnings_in_tests;
-        self
-    }
-
-    /// When true, suppress ALL seismic warnings (code >= 10000) globally.
-    #[must_use]
-    pub fn set_no_seismic_warnings(mut self, no_seismic_warnings: bool) -> Self {
-        self.no_seismic_warnings = no_seismic_warnings;
+    pub fn set_seismic_config(mut self, seismic_cfg: SeismicConfig) -> Self {
+        self.seismic_cfg = seismic_cfg;
         self
     }
 
@@ -668,8 +656,7 @@ impl<C: Compiler, T: ArtifactOutput<CompilerContract = C::CompilerContract>> Pro
             no_artifacts,
             ignored_error_codes,
             compiler_severity_filter,
-            seismic_warnings_in_tests,
-            no_seismic_warnings,
+            seismic_cfg,
             solc_jobs,
             offline,
             build_info,
@@ -693,8 +680,7 @@ impl<C: Compiler, T: ArtifactOutput<CompilerContract = C::CompilerContract>> Pro
             ignored_error_codes,
             ignored_file_paths,
             compiler_severity_filter,
-            seismic_warnings_in_tests,
-            no_seismic_warnings,
+            seismic_cfg,
             solc_jobs,
             build_info,
             settings,
@@ -711,8 +697,7 @@ impl<C: Compiler, T: ArtifactOutput<CompilerContract = C::CompilerContract>> Pro
             ignored_error_codes,
             ignored_file_paths,
             compiler_severity_filter,
-            seismic_warnings_in_tests,
-            no_seismic_warnings,
+            seismic_cfg,
             solc_jobs,
             offline,
             build_info,
@@ -740,8 +725,7 @@ impl<C: Compiler, T: ArtifactOutput<CompilerContract = C::CompilerContract>> Pro
             ignored_error_codes,
             ignored_file_paths,
             compiler_severity_filter,
-            seismic_warnings_in_tests,
-            no_seismic_warnings,
+            seismic_cfg,
             solc_jobs: solc_jobs
                 .or_else(|| std::thread::available_parallelism().ok().map(|n| n.get()))
                 .unwrap_or(1),


### PR DESCRIPTION
## Summary
Stacked on #21.

- Add `seismic_warnings_in_tests` flag — when true, shows all seismic warnings in test/script files (disables default suppression from #19)
- Add `no_seismic_warnings` flag — when true, suppresses ALL seismic warnings (>= 10000) globally
- `no_seismic_warnings` takes precedence over `seismic_warnings_in_tests`
- Both flags threaded through `CliSettings`, `Project`, `ProjectBuilder`, `ProjectCompileOutput`, and `should_ignore()`

## Context
Companion to SeismicSystems/seismic-foundry#180 — foundry exposes these as `seismic_warnings_test` and `no_seismic_warnings` in `foundry.toml`.

## Test plan
- [x] `RUSTFLAGS="-D warnings" cargo test` — 28 output tests pass, zero warnings
- [x] Tests cover: default suppression, both flags independently, precedence when both set